### PR TITLE
Unboxed tuples: Part 1

### DIFF
--- a/src/Backend/Lua/Syntax.hs
+++ b/src/Backend/Lua/Syntax.hs
@@ -23,7 +23,7 @@ data LuaStmt
   | LuaFornum Text LuaExpr LuaExpr LuaExpr [LuaStmt]
   | LuaFor [Text] [LuaExpr] [LuaStmt]
   | LuaLocal [LuaVar] [LuaExpr]
-  | LuaReturn LuaExpr
+  | LuaReturn [LuaExpr]
   | LuaIfElse [(LuaExpr, [LuaStmt])]
   | LuaBreak
   | LuaCallS LuaExpr [LuaExpr]

--- a/src/Core/Arity.hs
+++ b/src/Core/Arity.hs
@@ -46,10 +46,11 @@ atomArity _ (Lit _) = Arity 0 True
 
 -- | Determine if the given term can be evaluated without side effects
 isPure :: IsVar a => ArityScope -> AnnTerm b a -> Bool
-isPure _ AnnAtom{}   = True
-isPure _ AnnExtend{} = True
-isPure _ AnnTyApp{}  = True
-isPure _ AnnCast{}  = True
+isPure _ AnnAtom{}    = True
+isPure _ AnnExtend{}  = True
+isPure _ AnnValues{} = True
+isPure _ AnnTyApp{}   = True
+isPure _ AnnCast{}    = True
 isPure s (AnnLet _ (One v) e) = isPure s e && isPure s (thd3 v)
 isPure s (AnnLet _ (Many vs) e) = isPure s e && all (isPure s . thd3) vs
 isPure s (AnnMatch _ _ bs) = all (isPure s . view armBody) bs
@@ -88,21 +89,21 @@ mapArity f (Arity a p) = Arity (f a) p
 -- | Various built-in functions with a predetermined arity
 opArity :: VarMap.Map Arity
 opArity = VarMap.fromList . map (flip Arity True <$>) $
-    [ (vOpAdd, 2), (vOpAddF, 2)
-    , (vOpSub, 2), (vOpSubF, 2)
-    , (vOpMul, 2), (vOpMulF, 2)
-    , (vOpDiv, 2), (vOpDivF, 2)
-    , (vOpExp, 2), (vOpExpF, 2)
-    , (vOpLt,  2), (vOpLtF,  2)
-    , (vOpGt,  2), (vOpGtF,  2)
-    , (vOpLe,  2), (vOpLeF,  2)
-    , (vOpGe,  2), (vOpGeF,  2)
+    [ (vOpAdd, 1), (vOpAddF, 1)
+    , (vOpSub, 1), (vOpSubF, 1)
+    , (vOpMul, 1), (vOpMulF, 1)
+    , (vOpDiv, 1), (vOpDivF, 1)
+    , (vOpExp, 1), (vOpExpF, 1)
+    , (vOpLt,  1), (vOpLtF,  1)
+    , (vOpGt,  1), (vOpGtF,  1)
+    , (vOpLe,  1), (vOpLeF,  1)
+    , (vOpGe,  1), (vOpGeF,  1)
     , (vLAZY,  2)
 
-    , (vOpConcat,  2)
+    , (vOpConcat,  1)
 
-    , (vOpEq, 3)
-    , (vOpNe, 3)
-    , (vOpOr, 2)
-    , (vOpAnd, 2)
+    , (vOpEq, 2)
+    , (vOpNe, 2)
+    , (vOpOr, 1)
+    , (vOpAnd, 1)
     ]

--- a/src/Core/Builtin.hs
+++ b/src/Core/Builtin.hs
@@ -83,15 +83,17 @@ builtinVarList :: (IsVar a, IsVar b) => [(a, Type b)]
 builtinVarList = vars where
   op x t = (fromVar x, t)
 
+  tupTy = ValuesTy
   arrTy = ForallTy Irrelevant
-  boolOp = ForallTy Irrelevant tyBool (ForallTy Irrelevant tyBool tyBool)
-  intOp = tyInt `arrTy` (tyInt `arrTy` tyInt)
-  floatOp = tyFloat `arrTy` (tyFloat `arrTy` tyFloat)
-  stringOp = tyString `arrTy` (tyString `arrTy` tyString)
-  intCmp = tyInt `arrTy` (tyInt `arrTy` tyBool)
-  floatCmp = tyInt `arrTy` (tyInt `arrTy` tyBool)
 
-  cmp = ForallTy (Relevant name) StarTy $ VarTy name `arrTy` (VarTy name `arrTy` tyBool)
+  boolOp = ForallTy Irrelevant tyBool (ForallTy Irrelevant tyBool tyBool)
+  intOp = tupTy [tyInt, tyInt] `arrTy` tyInt
+  floatOp = tupTy [tyFloat, tyFloat] `arrTy` tyFloat
+  stringOp = tupTy [tyString, tyString] `arrTy` tyString
+  intCmp = tupTy [tyInt, tyInt] `arrTy` tyBool
+  floatCmp = tupTy [tyFloat, tyFloat] `arrTy` tyBool
+
+  cmp = ForallTy (Relevant name) StarTy $ tupTy [VarTy name, VarTy name] `arrTy` tyBool
 
   name = fromVar tyvarA
 

--- a/src/Core/Free.hs
+++ b/src/Core/Free.hs
@@ -127,6 +127,11 @@ tagFreeTerm ann var = tagTerm where
         fv = mconcat (fvf : fvfs)
     in (fv, AnnExtend (ann an fv) f' fs')
 
+  tagTerm (AnnValues an xs) =
+    let (fvfs, xs') = unzip (map tagAtom xs)
+        fv = mconcat fvfs
+    in (fv, AnnValues (ann an fv) xs')
+
   tagTerm (AnnTyApp an f ty) =
     let (fv, f') = tagAtom f
     in (fv, AnnTyApp (ann an fv) f' (conv ty))

--- a/src/Core/Occurrence.hs
+++ b/src/Core/Occurrence.hs
@@ -186,6 +186,11 @@ tagOccurTerm ann var = tagTerm where
         fv = occConcat (fvf : fvfs)
     in (fv, AnnExtend (ann an fv) f' fs')
 
+  tagTerm (AnnValues an xs) =
+    let (fvfs, xs') = unzip (map tagAtom xs)
+        fv = mconcat fvfs
+    in (fv, AnnValues (ann an fv) xs')
+
   tagTerm (AnnTyApp an f ty) =
     let (fv, f') = tagAtom f
     in (fv, AnnTyApp (ann an fv) f' (conv ty))

--- a/src/Core/Optimise/DeadCode.hs
+++ b/src/Core/Optimise/DeadCode.hs
@@ -75,6 +75,7 @@ deadCodePass = snd . freeS emptyScope Nothing where
   freeT s (TyApp f t) = TyApp <$> freeA s f <*> pure t
   freeT s (Cast f t) = Cast <$> freeA s f <*> pure t
   freeT s (Extend t rs) = Extend <$> freeA s t <*> traverse (third3A (freeA s)) rs
+  freeT s (Values xs) = Values <$> traverse (freeA s) xs
   freeT s (Let (One vs@(v, ty, e)) b) =
     let s' = extendPureLets s [vs]
         (fe, e') = freeT s e

--- a/src/Core/Optimise/Inline.hs
+++ b/src/Core/Optimise/Inline.hs
@@ -77,6 +77,7 @@ inlineVariablePass = transS (InlineScope mempty mempty) where
       f' -> pure $ TyApp f' t
   transT s (Extend t rs) = Extend <$> transA s t
                                   <*> traverse (third3A (transA s)) rs
+  transT s (Values xs) = Values <$> traverse (transA s) xs
   transT s (Let (One var) body) = do
     var' <- third3A (transT s) var
     body' <- transT (extendVar var s) body
@@ -113,5 +114,6 @@ scoreTerm s (Let (One v) e) = scoreTerm s (thd3 v) + scoreTerm s e
 scoreTerm s (Let (Many vs) e) = sum (map (scoreTerm s . thd3) vs) + scoreTerm s e
 scoreTerm s (Match e bs) = scoreAtom s e + sum (map (scoreTerm s . view armBody) bs)
 scoreTerm s (Extend e rs) = scoreAtom s e + sum (map (scoreAtom s . thd3) rs)
+scoreTerm s (Values xs) = sum (map (scoreAtom s) xs)
 scoreTerm s (TyApp t _) = scoreAtom s t
 scoreTerm s (Cast t _) = scoreAtom s t

--- a/src/Core/Optimise/Joinify.hs
+++ b/src/Core/Optimise/Joinify.hs
@@ -55,4 +55,5 @@ matchJoinPass = traverse transS where
     Let (Many vs') <$> transT r
 
   transT (Extend t rs) = Extend <$> transA t <*> traverse (third3A transA) rs
+  transT (Values xs) = Values <$> traverse transA xs
   transT (Match t bs) = Match <$> transA t <*> traverse (armBody %%~ transT) bs

--- a/src/Core/Optimise/Newtype.hs
+++ b/src/Core/Optimise/Newtype.hs
@@ -88,6 +88,7 @@ goBinding ss m = traverse (third3A (fmap (substitute ss) . goTerm)) where
     e' <- goTerm e
     Let (One (v, t, e')) <$> goTerm b
   goTerm (Extend a as) = Extend <$> goAtom a <*> traverse (third3A goAtom) as
+  goTerm (Values xs) = Values <$> traverse goAtom xs
   goTerm (TyApp f t) = TyApp <$> goAtom f <*> pure t
   goTerm (Cast f t) = Cast <$> goAtom f <*> pure t
   goTerm (Match a x) = case newtypeMatch m x of

--- a/src/Core/Optimise/Sinking.hs
+++ b/src/Core/Optimise/Sinking.hs
@@ -100,7 +100,7 @@ sinkTerm s (AnnMatch _ t bs) =
 sinkTerm s (AnnTyApp _ f ty) = flushBinds (sinkable s) (TyApp (sinkAtom (nullBinds s) f) ty)
 sinkTerm s (AnnExtend _ f fs) = flushBinds (sinkable s) (Extend (sinkAtom s' f) (map (third3 (sinkAtom s')) fs))
   where s' = nullBinds s
-
+sinkTerm s (AnnValues _ xs) = flushBinds (sinkable s) (Values (map (sinkAtom (nullBinds s)) xs))
 sinkTerm s (AnnCast _ f co) = flushBinds (sinkable s) (Cast (sinkAtom (nullBinds s) f) co)
 
 flushBinds :: [Sinkable a] -> Term a -> Term a

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -529,7 +529,7 @@ localGenStrat bg ex ty = do
         (Set.member v bound || Set.member v cons)
        && maybe True Set.null (types ^. at (unTvName v) . to (fmap ftv))
 
-  if (Set.foldr ((&&) . generalisable) True (freeIn ex Set.\\ bg)) && value ex
+  if Set.foldr ((&&) . generalisable) True (freeIn ex Set.\\ bg) && value ex
      then generalise (BecauseOf ex) ty
      else annotateKind (BecauseOf ex) ty
 

--- a/tests/lua/arithmetic.lua
+++ b/tests/lua/arithmetic.lua
@@ -3,9 +3,7 @@ do
     __tag = "__builtin_unit"
   }
   local function main (f)
-    local a = f(1)
-    local b = f(2)
-    return a + b
+    return f(1) + f(2)
   end
   main()
 end

--- a/tests/lua/match_consumed.lua
+++ b/tests/lua/match_consumed.lua
@@ -2,11 +2,6 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function _plus (l)
-    return function (r)
-      return l + r
-    end
-  end
   local None = {
     __tag = "None"
   }
@@ -22,9 +17,7 @@ do
       if x.__tag == "None" then
         return f(a)
       elseif x.__tag == "Some" then
-        local cw = x[1] * 2
-        local ct = _plus(a)
-        return f(ct(cw))
+        return f(a + x[1] * 2)
       end
     end
   end

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -2,20 +2,17 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function _star (l)
-    return function (r)
-      return l * r
-    end
-  end
-  local function _plus (l)
-    return function (r)
-      return l + r
+  local function _plus0 (au)
+    return function (av)
+      return au + av
     end
   end
   local main = {
-    _1 = _plus,
+    _1 = _plus0,
     _2 = {
-      _1 = _star(2),
+      _1 = function (ay)
+        return 2 * ay
+      end,
       _2 = {
         _1 = function (b)
           return b / 2

--- a/tests/lua/stream.lua
+++ b/tests/lua/stream.lua
@@ -2,11 +2,6 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function _dot_dot (l)
-    return function (r)
-      return l .. r
-    end
-  end
   local io_write = io.write
   local print = print
   local to_string = tostring
@@ -33,14 +28,12 @@ do
   end
   local main = (function ()
     local go
-    local nl = to_string
+    local no = to_string
     go = function (st)
       if st > 5 then
         return print("]")
       else
-        local mv = nl(st)
-        local mu = _dot_dot("'")
-        io_write(mu(mv .. "', "))
+        io_write("'" .. no(st) .. "', ")
         return go(st + 1)
       end
     end


### PR DESCRIPTION
It's almost midnight - I'm afraid I don't have energy to write a fancy commit message. Needless to say, the implementation is a little grim.

This implementation is intentionally very basic and restrictive:
 - Unboxed tuples can only (currently) appear on the left hand side of an arrow type. They cannot be returned.
 - We do not do any worker/wrapper transformation beyond binops within lower.
 - Codegen is probably broken.

This mainly intends to serve as a POC and a starting point for the codegen rewrite. 