### PR TITLE
Remove boolean operators

### DIFF
--- a/examples/gadt/vector.ml
+++ b/examples/gadt/vector.ml
@@ -25,6 +25,8 @@ type some_nat =
 
 type maybe 'a = Some of 'a | None ;;
 
+let left && (right : lazy 'a) = if left then force right else false
+
 (* uses supplied type signature *)
 let map (f : 'a -> 'b) (xs : vect 'n 'a) : vect 'n 'b =
   match xs with

--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -518,8 +518,7 @@ ops = VarMap.fromList
 
   , (vOpEq, "==")
   , (vOpNe, "~=")
-  , (vOpOr, "or")
-  , (vOpAnd, "and") ]
+  ]
 
 -- | Remap an Amulet binary op to the equivalent Lua operator
 remapOp :: IsVar a => a -> Text

--- a/src/Core/Arity.hs
+++ b/src/Core/Arity.hs
@@ -104,6 +104,4 @@ opArity = VarMap.fromList . map (flip Arity True <$>) $
 
     , (vOpEq, 2)
     , (vOpNe, 2)
-    , (vOpOr, 1)
-    , (vOpAnd, 1)
     ]

--- a/src/Core/Builtin.hs
+++ b/src/Core/Builtin.hs
@@ -64,10 +64,6 @@ vOpEq, vOpNe :: CoVar
 vOpEq = CoVar (-25) "==" ValueVar
 vOpNe = CoVar (-26) "<>" ValueVar
 
-vOpAnd, vOpOr :: CoVar
-vOpAnd = CoVar (-27) "&&" ValueVar
-vOpOr  = CoVar (-28) "||" ValueVar
-
 vError :: CoVar
 vError = CoVar (-29) "error" ValueVar
 
@@ -86,7 +82,6 @@ builtinVarList = vars where
   tupTy = ValuesTy
   arrTy = ForallTy Irrelevant
 
-  boolOp = ForallTy Irrelevant tyBool (ForallTy Irrelevant tyBool tyBool)
   intOp = tupTy [tyInt, tyInt] `arrTy` tyInt
   floatOp = tupTy [tyFloat, tyFloat] `arrTy` tyFloat
   stringOp = tupTy [tyString, tyString] `arrTy` tyString
@@ -106,7 +101,6 @@ builtinVarList = vars where
          , op vOpConcat stringOp
 
          , op vOpEq cmp, op vOpNe cmp
-         , op vOpOr boolOp, op vOpAnd boolOp
 
          , (fromVar vError, ForallTy (Relevant name) StarTy $ tyString `arrTy` VarTy name)
          , (fromVar vLAZY, ForallTy (Relevant name) StarTy $ (tyUnit `arrTy` VarTy name) `arrTy` AppTy tyLazy (VarTy name))

--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -613,5 +613,4 @@ boxedTys = VarMap.fromList
     , C.vOpConcat
 
     , C.vOpEq, C.vOpNe
-    , C.vOpOr, C.vOpAnd
     ]

--- a/src/Core/Optimise/Reduce.hs
+++ b/src/Core/Optimise/Reduce.hs
@@ -245,23 +245,6 @@ reduceTerm s e@(App (Ref v _) (Ref a _))
       [Lit (Int 0), _] | n == vOpMul -> num 0
       [x, Lit (Int 1)] | n == vOpDiv -> Atom x
 
-      -- Primitive boolean reductions
-      [Lit LitTrue,  Lit LitTrue]  | n == vOpAnd -> bool True
-      [Lit _,        Lit _]        | n == vOpAnd -> bool False
-      [Lit LitFalse, Lit LitFalse] | n == vOpOr  -> bool False
-      [Lit _,        Lit _]        | n == vOpOr  -> bool True
-
-      -- Partial boolean reductions
-      [_, Lit LitFalse]  | n == vOpAnd -> bool False
-      [Lit LitFalse,  _] | n == vOpAnd -> bool False
-      [x, Lit LitTrue]   | n == vOpAnd -> Atom x
-      [Lit LitTrue,  x]  | n == vOpAnd -> Atom x
-      [_, Lit LitTrue]   | n == vOpOr  -> bool True
-      [Lit LitTrue,  _]  | n == vOpOr  -> bool True
-      [x, Lit LitFalse]  | n == vOpOr  -> Atom x
-      [Lit LitFalse,  x] | n == vOpOr  -> Atom x
-
-
       -- Primitive string reductions
       [Lit (Str l), Lit (Str r)]  | n == vOpConcat -> str (l `T.append` r)
 

--- a/src/Syntax/Resolve/Scope.hs
+++ b/src/Syntax/Resolve/Scope.hs
@@ -55,7 +55,6 @@ builtinScope = Scope
                { varScope = build [ "+", "-", "*", "/", "**", "^"
                                   , "+.", "-.", "*.", "/.", "**.", "^."
                                   , "<", ">", ">=", "<=", "==", "<>"
-                                  , "||", "&&"
                                   , "@@", "lazy", "force" ]
                , tyScope    = Map.insert (Name "lazy") (SVar (TgName "lazy" (-34))) $ build [ "int", "string", "bool", "unit", "float" ]
                , tyvarScope = mempty

--- a/src/Types/Infer/Builtin.hs
+++ b/src/Types/Infer/Builtin.hs
@@ -34,7 +34,6 @@ builtinsEnv = envOf (scopeFromList builtin) where
   tp :: T.Text -> (Var Resolved, Type Typed)
   tp x = (TgInternal x, TyType)
 
-  boolOp = tyBool `TyArr` (tyBool `TyArr` tyBool)
   intOp = tyInt `TyArr` (tyInt `TyArr` tyInt)
   floatOp = tyFloat `TyArr` (tyFloat `TyArr` tyFloat)
   stringOp = tyString `TyArr` (tyString `TyArr` tyString)
@@ -50,7 +49,6 @@ builtinsEnv = envOf (scopeFromList builtin) where
       , op "<" intCmp, op ">" intCmp, op ">=" intCmp, op "<=" intCmp
       , op "<." floatCmp, op ">." floatCmp, op ">=." floatCmp, op "<=." floatCmp
       , op "==" cmp, op "<>" cmp
-      , op "||" boolOp, op "&&" boolOp
       , (TgInternal "lazy", TyForall a (Just TyType) $ (tyUnit `TyArr` TyVar a) `TyArr` TyApp tyLazy (TyVar a))
       , (TgInternal "force", TyForall a (Just TyType) $ TyApp tyLazy (TyVar a) `TyArr` TyVar a)
       , tp "int", tp "string", tp "bool", tp "unit", tp "float", (TgName "lazy" (-34), TyArr TyType TyType)

--- a/src/Types/Infer/Outline.hs
+++ b/src/Types/Infer/Outline.hs
@@ -110,6 +110,4 @@ builtinOps =
     , (TgInternal "<=.", tyBool)
     , (TgInternal "==", tyBool)
     , (TgInternal "<>", tyBool)
-    , (TgInternal "&&", tyBool)
-    , (TgInternal "||", tyBool)
     ]

--- a/tests/lua/and.lua
+++ b/tests/lua/and.lua
@@ -1,0 +1,32 @@
+do
+  local __builtin_unit = {
+    __tag = "__builtin_unit"
+  }
+  local function __builtin_force (x)
+    if x[2.0] then
+      return x[1.0]
+    else
+      x[1.0], x[2.0] = x[1.0](__builtin_unit), true
+      return x[1.0]
+    end
+  end
+  local function __builtin_Lazy (x)
+    return {
+      [1.0] = x,
+      [2.0] = false,
+      __tag = "lazy"
+    }
+  end
+  local function main (f)
+    if f(1) then
+      local ca = __builtin_Lazy(function (bx)
+        return f(2)
+      end)
+      local bt = __builtin_force
+      return bt(ca)
+    else
+      return false
+    end
+  end
+  main()
+end

--- a/tests/lua/and.ml
+++ b/tests/lua/and.ml
@@ -1,0 +1,3 @@
+let left && (right : lazy 'a) = if left then force right else false
+
+let main f = f 1 && f 2


### PR DESCRIPTION
These are not technically compiled correctly anyway (they are lazy when they should not be), so it would be better to handle this within the codegen.

That being said, the currently produced code is somewhat terrible: we need to eliminate lazy/force pairing and be smart about detecting such combinations of if/else blocks.

Note that this still keeps the operator precedence rules for `&&` and `||`.