### PR TITLE
Remove main

### DIFF
--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -64,7 +64,7 @@ compile opt (file:files) = runIdentity . flip evalNameyT firstName $ do
       optm <- case opt of
                 Do -> optimise lower
                 Don't -> pure (deadCodePass (reducePass lower))
-      pure (CSuccess ve prg lower optm (compileProgram env optm) env)
+      pure (CSuccess ve prg lower optm (compileProgram optm) env)
 
     Left err -> pure err
 

--- a/compiler/Repl.hs
+++ b/compiler/Repl.hs
@@ -141,7 +141,7 @@ runRepl = do
       case core of
         Nothing -> pure ()
         Just (vs, prog, core, state') -> do
-          let (luaStmt, escape') = B.emitProgramWith (inferScope state') (escapeScope state') (tagOccursVar core)
+          let (luaStmt, escape') = B.emitProgramWith (escapeScope state') (tagOccursVar core)
               luaExpr = LuaDo . map patchupLua $ luaStmt
               luaSyntax = T.unpack . display . uncommentDoc . renderPretty 0.8 100 . pretty $ luaExpr
 

--- a/compiler/Test/Core/Backend.hs
+++ b/compiler/Test/Core/Backend.hs
@@ -28,11 +28,11 @@ result file contents = fst . flip runNamey firstName $ do
   let (Just parsed, _) = runParser file (L.fromStrict contents) parseTops
   Right (resolved, _) <- resolveProgram RS.builtinScope RS.emptyModules parsed
   desugared <- desugarProgram resolved
-  Right (inferred, env) <- inferProgram builtinsEnv desugared
+  Right (inferred, _) <- inferProgram builtinsEnv desugared
   lower <- runLowerT (lowerProg inferred)
   optm <- optimise lower
   pure . display . uncommentDoc . renderPretty 0.8 120 . (<##>empty)
-       . pretty . compileProgram env $ optm
+       . pretty . compileProgram $ optm
 
 tests :: IO TestTree
 tests = testGroup "Tests.Core.Backend" <$> goldenDirOn result (++".lua") "tests/lua/" ".ml"

--- a/src/Backend/Lua.hs
+++ b/src/Backend/Lua.hs
@@ -16,10 +16,8 @@ import Core.Occurrence
 import Core.Core
 import Core.Var
 
-import Syntax.Types
-
 -- | Compile a collection of "Core"'s top-level statements to a Lua
 -- statement
-compileProgram :: IsVar a => Env -> [Stmt a] -> LuaStmt
-compileProgram e = LuaDo . (unitDef :) . addOperators . emitProgram e . tagOccursVar where
+compileProgram :: IsVar a => [Stmt a] -> LuaStmt
+compileProgram = LuaDo . (unitDef :) . addOperators . emitProgram . tagOccursVar where
   unitDef = LuaLocal [ LuaName "__builtin_unit" ] [ LuaTable [ (LuaString "__tag", LuaString "__builtin_unit") ] ]

--- a/tests/lua/and.lua
+++ b/tests/lua/and.lua
@@ -17,16 +17,19 @@ do
       __tag = "lazy"
     }
   end
-  local function main (f)
-    if f(1) then
-      local ca = __builtin_Lazy(function (bx)
-        return f(2)
+  local bottom = nil
+  local cx = (function ()
+    local cv = bottom
+    if cv(1) then
+      local ct = __builtin_Lazy(function (cq)
+        return cv(2)
       end)
-      local bt = __builtin_force
-      return bt(ca)
+      local cm = __builtin_force
+      local dn = cm(ct)
+      local cu = bottom
+      return cu(dn)
     else
-      return false
+      return bottom(false)
     end
-  end
-  main()
+  end)()
 end

--- a/tests/lua/and.ml
+++ b/tests/lua/and.ml
@@ -1,3 +1,6 @@
 let left && (right : lazy 'a) = if left then force right else false
 
 let main f = f 1 && f 2
+
+external val bottom : 'a = "nil"
+let () = bottom (main bottom)

--- a/tests/lua/arithmetic.lua
+++ b/tests/lua/arithmetic.lua
@@ -2,8 +2,11 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function main (f)
-    return f(1) + f(2)
-  end
-  main()
+  local bottom = nil
+  local cg = (function ()
+    local ce = bottom
+    local cf = ce(1) + ce(2)
+    local cd = bottom
+    return cd(cf)
+  end)()
 end

--- a/tests/lua/arithmetic.ml
+++ b/tests/lua/arithmetic.ml
@@ -3,3 +3,6 @@ let main f =
   let b = f 2
   let c = (+) a
   c b
+
+external val bottom : 'a = "nil"
+let () = bottom (main bottom)

--- a/tests/lua/escape.lua
+++ b/tests/lua/escape.lua
@@ -2,10 +2,11 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local main = {
+  local bottom = nil
+  local s = bottom({
     quote = "\"",
     line = "\n",
     tab = "\t",
     hex = "\17"
-  }
+  })
 end

--- a/tests/lua/escape.ml
+++ b/tests/lua/escape.ml
@@ -1,4 +1,7 @@
-let main = { quote = "\""
+external val bottom : 'a = "nil"
+
+let () = bottom
+           { quote = "\""
            , line  =  "\n"
            , tab = "\t"
            , hex = "\x11"

--- a/tests/lua/function_order.lua
+++ b/tests/lua/function_order.lua
@@ -2,13 +2,13 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function main (f)
-    return function (g)
-      local a = f(1)
-      local b = f(2)
-      local c = f(3)
-      return g(b)(c)(a)
-    end
-  end
-  main()()
+  local bottom = nil
+  local dd = (function ()
+    local da = bottom
+    local a = da(1)
+    local b = da(2)
+    local c = da(3)
+    local dc = bottom
+    return dc(b)(c)(a)
+  end)()
 end

--- a/tests/lua/function_order.ml
+++ b/tests/lua/function_order.ml
@@ -3,3 +3,6 @@ let main (f : int -> int) g =
   let b = f 2
   let c = f 3
   g b c a
+
+external val bottom : 'a = "nil"
+let () = main bottom bottom

--- a/tests/lua/if.lua
+++ b/tests/lua/if.lua
@@ -2,12 +2,17 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function main (f)
-    if f(1) then
-      return f(2)
+  local bottom = nil
+  local bd = (function ()
+    local bb = bottom
+    if bb(1) then
+      local bh = bb(2)
+      local ba = bottom
+      return ba(bh)
     else
-      return f(3)
+      local bi = bb(3)
+      local ba = bottom
+      return ba(bi)
     end
-  end
-  main()
+  end)()
 end

--- a/tests/lua/if.ml
+++ b/tests/lua/if.ml
@@ -3,3 +3,6 @@
 let main f = if f 1
              then f 2
              else f 3
+
+external val bottom : 'a = "nil"
+let () = bottom (main bottom)

--- a/tests/lua/let_pattern.lua
+++ b/tests/lua/let_pattern.lua
@@ -2,7 +2,7 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local dr = {
+  local de = {
     _1 = function (x)
       return x
     end,
@@ -10,13 +10,14 @@ do
       return x
     end
   }
-  local d = dr._1
-  local e = dr._2
-  local main = {
+  local d = de._1
+  local e = de._2
+  local bottom = nil
+  local dx = bottom({
     a = 3,
     b = 5,
     c = 6,
     d = d,
     e = e
-  }
+  })
 end

--- a/tests/lua/let_pattern.ml
+++ b/tests/lua/let_pattern.ml
@@ -12,4 +12,5 @@ let (b, c) = (5, 6)
 (* Test polymorphic binds *)
 let (d, e) = (id, id)
 
-let main = { a, b, c, d, e }
+external val bottom : 'a = "nil"
+let () = bottom { a, b, c, d, e }

--- a/tests/lua/match_consumed.lua
+++ b/tests/lua/match_consumed.lua
@@ -11,15 +11,19 @@ do
       [1] = x
     }
   end
-  local function main (f)
-    return function (x)
-      local a = f(1)
-      if x.__tag == "None" then
-        return f(a)
-      elseif x.__tag == "Some" then
-        return f(a + x[1] * 2)
-      end
+  local bottom = nil
+  local ds = (function ()
+    local _do = bottom
+    local a = _do(1)
+    local dq = bottom
+    if dq.__tag == "None" then
+      local fx = _do(a)
+      local dn = bottom
+      return dn(fx)
+    elseif dq.__tag == "Some" then
+      local fy = _do(a + dq[1] * 2)
+      local dn = bottom
+      return dn(fy)
     end
-  end
-  main()()
+  end)()
 end

--- a/tests/lua/match_consumed.ml
+++ b/tests/lua/match_consumed.ml
@@ -11,3 +11,6 @@ let main f x =
           | None -> 0
           | Some x -> x * 2
   in f (a + b)
+
+external val bottom : 'a = "nil"
+let () = bottom (main bottom bottom)

--- a/tests/lua/match_multi.lua
+++ b/tests/lua/match_multi.lua
@@ -2,9 +2,11 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function main (f)
-    local ai = f(__builtin_unit)
-    return ai.a + ai.b
-  end
-  main()
+  local bottom = nil
+  local bm = (function ()
+    local bc = bottom(__builtin_unit)
+    local bl = bc.a + bc.b
+    local bi = bottom
+    return bi(bl)
+  end)()
 end

--- a/tests/lua/match_multi.ml
+++ b/tests/lua/match_multi.ml
@@ -1,3 +1,6 @@
 let main f =
   match f () with
   | { a = a, b = b } -> a + b
+
+external val bottom : 'a = "nil"
+let () = bottom (main bottom)

--- a/tests/lua/newtype.lua
+++ b/tests/lua/newtype.lua
@@ -26,11 +26,12 @@ do
       [1] = x
     }
   end
-  local function main (x)
+  local bottom = nil
+  local fa = (function ()
+    local x = bottom
     x(Foo)
     x(Bar)
     x(It)
     return x(Mk)
-  end
-  main()
+  end)()
 end

--- a/tests/lua/newtype.ml
+++ b/tests/lua/newtype.ml
@@ -15,3 +15,6 @@ let main (x : forall 'a. 'a -> unit) =
   x Bar (* Bar's worker has a type argument, so it'll get inlined *)
   x It (* Doesn't get inlined *)
   x Mk (* Mk's worker has a type argument, so it'll get inlined *)
+
+external val bottom : 'a = "nil"
+let () = main bottom

--- a/tests/lua/record_extend.lua
+++ b/tests/lua/record_extend.lua
@@ -2,15 +2,17 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function main (x)
-    local __o, __n = x, {
+  local bottom = nil
+  local au = (function ()
+    local __o, __n = bottom, {
       
     }
     for k, v in pairs(__o) do
       __n[k] = v
     end
     __n.x = 1
-    return __n
-  end
-  main()
+    local at = __n
+    local aq = bottom
+    return aq(at)
+  end)()
 end

--- a/tests/lua/record_extend.ml
+++ b/tests/lua/record_extend.ml
@@ -1,1 +1,4 @@
 let main x = { x with x = 1 }
+
+external val bottom : 'a = "nil"
+let () = bottom (main bottom)

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -2,25 +2,27 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function _plus0 (au)
-    return function (av)
-      return au + av
+  local function _plus0 (bq)
+    return function (br)
+      return bq + br
     end
   end
   local main = {
     _1 = _plus0,
     _2 = {
-      _1 = function (ay)
-        return 2 * ay
+      _1 = function (bu)
+        return 2 * bu
       end,
       _2 = {
-        _1 = function (b)
-          return b / 2
+        _1 = function (d)
+          return d / 2
         end,
-        _2 = function (c)
-          return c.foo
+        _2 = function (e)
+          return e.foo
         end
       }
     }
   }
+  local bottom = nil
+  local bp = bottom(main)
 end

--- a/tests/lua/section.ml
+++ b/tests/lua/section.ml
@@ -1,2 +1,5 @@
 (* Ensure that operator and record sections result in semi-sane code. *)
 let main = ( (+), (2*), (/2), (.foo) )
+
+external val bottom : 'a = "nil"
+let () = bottom main

--- a/tests/lua/stream.lua
+++ b/tests/lua/stream.lua
@@ -28,16 +28,18 @@ do
   end
   local main = (function ()
     local go
-    local nr = to_string
+    local oh = to_string
     go = function (st)
       if st > 5 then
         return print("]")
       else
-        io_write("'" .. nr(st) .. "', ")
+        io_write("'" .. oh(st) .. "', ")
         return go(st + 1)
       end
     end
     io_write("[")
     return go(1)
   end)()
+  local bottom = nil
+  local ok = bottom(main)
 end

--- a/tests/lua/stream.ml
+++ b/tests/lua/stream.ml
@@ -39,3 +39,6 @@ let main = range (1, 5) |> dump_stream to_string
  * of Stream, Skip, Yield or Done (even though at this time the compiler will
  * generate code for them)
  *)
+
+external val bottom : 'a = "nil"
+let () = bottom main

--- a/tests/lua/tuple_literal.lua
+++ b/tests/lua/tuple_literal.lua
@@ -2,17 +2,20 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function main (f)
-    local a = f(1)
-    local b = f(2)
-    local c = f(3)
-    return {
+  local bottom = nil
+  local ck = (function ()
+    local ci = bottom
+    local a = ci(1)
+    local b = ci(2)
+    local c = ci(3)
+    local cj = {
       _1 = b,
       _2 = {
         _1 = c,
         _2 = a
       }
     }
-  end
-  main()
+    local cg = bottom
+    return cg(cj)
+  end)()
 end

--- a/tests/lua/tuple_literal.ml
+++ b/tests/lua/tuple_literal.ml
@@ -9,3 +9,7 @@ let main f =
   let b = f 2
   let c = f 3
   ( b, c, a )
+
+
+external val bottom : 'a = "nil"
+let () = bottom (main bottom)


### PR DESCRIPTION
We never did anything interesting with main, and our calling of it was rather broken, so it's probably better to remove it. People can now write this instead:

```ml
let () = f x
```

This is closer to how other MLs handle it, which is always nice. We can also remove some pretty ugly code from the backend.

The main disadvantage here is that it breaks a large number of our codegen tests. We used to use `main` to inject opaque values. As this now has no special meaning, it'll be stripped and so the test won't emit anything!

For now, I've fixed this by calling `main` with a `bottom : 'a` value:

```ml
let main f = ...

external val bottom : 'a = "nil"
let () = bottom (main bottom)
```

This definitely is pretty ugly (and can generate some awful code), but I'm OK with this for now. Hopefully the backend rewrite (which is increasingly reaching the status of Urn's resolver rewrite) will clean up a lot of these.