### PR TITLE
Make lambdas terms rather than atoms

### DIFF
--- a/src/Core/Free.hs
+++ b/src/Core/Free.hs
@@ -72,14 +72,6 @@ tagFreeTerm ann var = tagTerm where
   tagAtom (Lit l) = (mempty, Lit l)
   tagAtom (Ref a ty) = (VarSet.singleton (toVar a)
                        , Ref (var a True) (conv ty))
-  tagAtom (Lam (TermArgument arg ty) bod) =
-    let (fv, bod') = tagTerm bod
-    in (VarSet.delete (toVar arg) fv
-       , Lam (TermArgument (var' arg fv) (conv ty)) bod')
-  tagAtom (Lam (TypeArgument arg ty) bod) =
-    let (fv, bod') = tagTerm bod
-    in (fv
-       , Lam (TypeArgument (var arg True) (conv ty)) bod')
 
   tagTerm (AnnAtom an a) =
     let (fv, a') = tagAtom a
@@ -90,6 +82,16 @@ tagFreeTerm ann var = tagTerm where
         (fvx, x') = tagAtom x
         fv = fvf <> fvx
     in (fv, AnnApp (ann an fv) f' x')
+
+  tagTerm (AnnLam an (TermArgument arg ty) bod) =
+    let (fv, bod') = tagTerm bod
+        fv' = VarSet.delete (toVar arg) fv
+    in ( fv
+       , AnnLam (ann an fv') (TermArgument (var' arg fv) (conv ty)) bod')
+  tagTerm (AnnLam an (TypeArgument arg ty) bod) =
+    let (fv, bod') = tagTerm bod
+    in ( fv
+       , AnnLam (ann an fv) (TypeArgument (var arg True) (conv ty)) bod')
 
   tagTerm (AnnLet an (One (v, ty, e)) r) =
     let (fve, e') = tagTerm e

--- a/src/Core/Optimise/Joinify.hs
+++ b/src/Core/Optimise/Joinify.hs
@@ -17,13 +17,13 @@ matchJoinPass = traverse transS where
 
   transA t@Ref{} = pure t
   transA t@Lit{} = pure t
-  transA (Lam arg b) = Lam arg <$> transT b
 
   transT (Atom a) = Atom <$> transA a
   transT (App f a) = App <$> transA f <*> transA a
   transT (TyApp f t) = flip TyApp t <$> transA f
   transT (Cast f t) = flip Cast t <$> transA f
 
+  transT (Lam arg b) = Lam arg <$> transT b
   transT (Let (One (name, nameTy, Match sc as)) cont) = do
     join <- fromVar <$> fresh ValueVar
     let Just res = approximateType cont
@@ -43,7 +43,7 @@ matchJoinPass = traverse transS where
         shoveJoin j t ex = error ("What: shoveJoin " ++ show j ++ " " ++ show t ++ " " ++ show ex)
 
     as <- traverse (shoveJoinArm (Ref join joinTy) joinTy) as
-    transT (Let (One (join, joinTy, Atom (Lam (TermArgument name nameTy) cont)))
+    transT (Let (One (join, joinTy, Lam (TermArgument name nameTy) cont))
               (Match sc as))
 
   transT (Let (One var) r) = do

--- a/src/Core/Types.hs
+++ b/src/Core/Types.hs
@@ -29,8 +29,6 @@ arity _ = 0
 
 approximateAtomType :: IsVar a => Atom a -> Maybe (Type a)
 approximateAtomType (Ref _ t) = pure t
-approximateAtomType (Lam (TypeArgument v k) f) = ForallTy (Relevant v) k <$> approximateType f
-approximateAtomType (Lam (TermArgument _ t) f) = ForallTy Irrelevant t <$> approximateType f
 approximateAtomType (Lit l) = pure . fmap fromVar $ case l of
   Int{} -> tyInt
   Float{} -> tyFloat
@@ -46,6 +44,8 @@ approximateType (Cast _ phi) = snd <$> relates phi
 approximateType (App f _) = do
   ForallTy _ _ d <- approximateAtomType f
   pure d
+approximateType (Lam (TypeArgument v k) f) = ForallTy (Relevant v) k <$> approximateType f
+approximateType (Lam (TermArgument _ t) f) = ForallTy Irrelevant t <$> approximateType f
 approximateType (Let _ e) = approximateType e
 approximateType (Match _ xs) = case xs of
   (x:_) -> approximateType (x ^. armBody)

--- a/tests/lua/and.lua
+++ b/tests/lua/and.lua
@@ -18,16 +18,16 @@ do
     }
   end
   local bottom = nil
-  local cx = (function ()
-    local cv = bottom
-    if cv(1) then
-      local ct = __builtin_Lazy(function (cq)
-        return cv(2)
+  local cy = (function ()
+    local cw = bottom
+    if cw(1) then
+      local cu = __builtin_Lazy(function (cq)
+        return cw(2)
       end)
       local cm = __builtin_force
-      local dq = cm(ct)
-      local cu = bottom
-      return cu(dq)
+      local dt = cm(cu)
+      local cv = bottom
+      return cv(dt)
     else
       return bottom(false)
     end

--- a/tests/lua/match_consumed.lua
+++ b/tests/lua/match_consumed.lua
@@ -17,13 +17,13 @@ do
     local a = _do(1)
     local dq = bottom
     if dq.__tag == "None" then
-      local ga = _do(a)
-      local dn = bottom
-      return dn(ga)
-    elseif dq.__tag == "Some" then
-      local gb = _do(a + dq[1] * 2)
+      local gb = _do(a)
       local dn = bottom
       return dn(gb)
+    elseif dq.__tag == "Some" then
+      local gc = _do(a + dq[1] * 2)
+      local dn = bottom
+      return dn(gc)
     end
   end)()
 end

--- a/tests/lua/newtype.lua
+++ b/tests/lua/newtype.lua
@@ -27,11 +27,11 @@ do
     }
   end
   local bottom = nil
-  local fa = (function ()
-    local x = bottom
-    x(Foo)
-    x(Bar)
-    x(It)
-    return x(Mk)
+  local fb = (function ()
+    local fa = bottom
+    fa(Foo)
+    fa(Bar)
+    fa(It)
+    return fa(Mk)
   end)()
 end

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -2,16 +2,16 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local function _plus0 (bt)
-    return function (bu)
-      return bt + bu
+  local function _plus0 (bv)
+    return function (bw)
+      return bv + bw
     end
   end
   local main = {
     _1 = _plus0,
     _2 = {
-      _1 = function (bx)
-        return 2 * bx
+      _1 = function (bz)
+        return 2 * bz
       end,
       _2 = {
         _1 = function (d)
@@ -24,5 +24,5 @@ do
     }
   }
   local bottom = nil
-  local bp = bottom(main)
+  local br = bottom(main)
 end

--- a/tests/lua/stream.lua
+++ b/tests/lua/stream.lua
@@ -28,12 +28,11 @@ do
   end
   local main = (function ()
     local go
-    local oh = to_string
     go = function (st)
       if st > 5 then
         return print("]")
       else
-        io_write("'" .. oh(st) .. "', ")
+        io_write("'" .. to_string(st) .. "', ")
         return go(st + 1)
       end
     end


### PR DESCRIPTION
There are several reasons for this

 - It is easier to generate code for term lambdas, as they can contain arbitrary statements.
 - It is easier to pattern match on variables containing lambdas, as they will be stored as a separate variable.
 - Atoms no longer contain code - they are simply made up of references and literals - thus some handling of them can be simplified.

