### PR TITLE
Rewrite core lint

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -103,6 +103,7 @@ executable lexer
                      , Text.Pretty.Ansi
                      , Text.Pretty.Note
                      , Text.Pretty.Semantic
+                     , Text.Pretty.Annotation
 
                      , Data.Span
                      , Data.Spanned
@@ -164,6 +165,7 @@ library amulet
                      , Text.Pretty.Ansi
                      , Text.Pretty.Note
                      , Text.Pretty.Semantic
+                     , Text.Pretty.Annotation
                      -- Data
                      , Data.Span
                      , Data.Reason

--- a/compiler/Test/Core/Lint.hs
+++ b/compiler/Test/Core/Lint.hs
@@ -84,8 +84,8 @@ testLint f file = do
       CSuccess c -> do
         c' <- f c
         case runLintOK (checkStmt emptyScope c') of
-          Right _ -> pure $ pure ()
-          Left es -> pure $ assertFailure $ "Core lint failed: " ++ displayS (pretty es)
+          Nothing -> pure $ pure ()
+          Just (_, es) -> pure $ assertFailure $ "Core lint failed: " ++ displayS (pretty es)
       CParse es -> pure $ assertFailure $ displayS $ vsep $ map (\e -> string "Parse error: " <+> pretty e <+> " at " <+> pretty (annotation e)) es
       CResolve e -> pure $ assertFailure $ "Resolution error: " ++ displayS (pretty e)
       CInfer e -> pure $ assertFailure $ "Type error: " ++ displayS (pretty e)

--- a/src/Text/Pretty/Annotation.hs
+++ b/src/Text/Pretty/Annotation.hs
@@ -1,0 +1,9 @@
+module Text.Pretty.Annotation where
+
+import Text.Pretty.Semantic
+
+class Annotation a where
+  annotated :: a -> Doc -> Doc
+
+instance Annotation () where
+  annotated () = id


### PR DESCRIPTION
 - Use applicatives instead of monads where possible, meaning a larger number of errors are accumulated.
 - Annotate the terms with errors, instead of building a list. This means we can report errors closer to their original location and hopefully make dumps easier to digest.
 - Provide the last pass to be run inside the error message. We could also modify this to include the program _before_ lint was run.

It's a long way from perfect, but hopefully it'll make it easier next time we hit a problem.

The diff is a little noisy as I shifted some checks into the top level, with the aim to make the term checks slightly less dense. Sorry! This would have been much simpler if `ApplicativeDo` handled more cases (or we'd just done a `MonadWriter (CoreErrors a) m`), but alas.

