### PR TITLE
Add a CSE pass

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -113,12 +113,14 @@ library amulet
   build-depends:       mtl >= 2.2 && < 2.3
                      , syb >= 0.7 && < 0.8
                      , text >= 1.2 && < 1.3
+                     , array >= 0.5 && < 0.6
                      , base >= 4.9 && < 4.12
                      , lens >= 4.15 && < 4.17
-                     , array >= 0.5 && < 0.6
+                     , hashable >= 1.2 && < 1.3
                      , containers >= 0.5 && < 0.6
                      , transformers >= 0.5 && < 0.6
                      , annotated-wl-pprint >= 0.7 && < 0.8
+                     , unordered-containers >= 0.2 && < 0.3
                      , pretty-show
 
   hs-source-dirs:      src
@@ -192,6 +194,7 @@ library amulet
                      , Core.Optimise.Newtype
                      , Core.Optimise.Joinify
                      , Core.Optimise.DeadCode
+                     , Core.Optimise.CommonExpElim
                      -- Backend
                      , Backend.Lua
                      , Backend.Lua.Emit

--- a/default.nix
+++ b/default.nix
@@ -36,28 +36,30 @@ let
   f = { mkDerivation, stdenv
       , mtl
       , syb
-      , text
+      , alex
       , base
-      , lens
-      , array
       , Diff
+      , lens
+      , text
+      , array
+      , happy
+      , hlint
       , hslua
       , HUnit
       , tasty
+      , hashable
       , hedgehog
-      , haskeline
       , directory
+      , haskeline
       , bytestring
       , containers
-      , transformers
       , pretty-show
-      , annotated-wl-pprint
       , tasty-hunit
-      , tasty-hedgehog_0_2_0_0
+      , transformers
       , tasty-ant-xml
-      , alex
-      , happy
-      , hlint
+      , annotated-wl-pprint
+      , unordered-containers
+      , tasty-hedgehog_0_2_0_0
       }:
       let alex' = haskell.lib.dontCheck alex;
           happy' = haskell.lib.dontCheck happy;
@@ -72,7 +74,8 @@ let
 
         libraryHaskellDepends = [
           annotated-wl-pprint array base bytestring containers lens
-          mtl pretty-show syb text transformers
+          mtl pretty-show syb text transformers hashable
+          unordered-containers
         ];
 
         executableHaskellDepends = [

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances, FlexibleContexts, ScopedTypeVariables,
-   DeriveFunctor, DeriveGeneric, PatternSynonyms, TemplateHaskell #-}
+   DeriveFunctor, DeriveGeneric, PatternSynonyms, TemplateHaskell,
+   DeriveAnyClass #-}
 -- | Amulet's explicitly-typed intermediate representation
 module Core.Core where
 
@@ -7,6 +8,7 @@ import Text.Pretty.Annotation
 import Text.Pretty.Semantic
 
 import qualified Data.VarSet as VarSet
+import Data.Hashable
 import Data.Function
 import Data.Triple
 import Data.Maybe
@@ -22,13 +24,13 @@ import GHC.Generics
 data Atom a
   = Ref a (Type a) -- ^ A reference to a variable, with an explicit type
   | Lit Literal -- ^ A literal.
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 -- | The domain of a lambda
 data Argument a
   = TermArgument a (Type a) -- ^ Computationally-relevant domain
   | TypeArgument a (Type a) -- ^ Type abstraction, erased at Emit-time.
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 -- | Terms.
 data AnnTerm b a
@@ -44,7 +46,7 @@ data AnnTerm b a
 
   | AnnTyApp b (Atom a) (Type a) -- ^ Eliminate a 'Lam' expecting a 'TypeArgument'
   | AnnCast b (Atom a) (Coercion a) -- ^ Cast an 'Atom' using some 'Coercion'.
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 -- | An 'AnnTerm' with '()' annotations.
 type Term = AnnTerm ()
@@ -91,7 +93,7 @@ pattern Cast a ty = AnnCast () a ty
 data AnnBinding b a
   = One (a, Type a, AnnTerm b a) -- ^ Acyclic binding group (no recursion)
   | Many [(a, Type a, AnnTerm b a)] -- ^ Cyclic, possibly mutually recursive binding groups
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 -- | An 'AnnBinding' with '()' annotations.
 type Binding = AnnBinding ()
@@ -104,7 +106,7 @@ data AnnArm b a = Arm
   , _armVars :: [(a, Type a)] -- ^ Bound value variables
   , _armTyvars :: [(a, Type a)] -- ^ Existential type variables
   }
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 -- | An 'Arm' with '()' annotations
 type Arm = AnnArm ()
@@ -117,7 +119,7 @@ data Pattern a
   | PatValues [Pattern a]
 
   | PatLit Literal
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 data Coercion a
   = SameRepr (Type a) (Type a)
@@ -133,7 +135,7 @@ data Coercion a
 
   | Domain (Coercion a)
   | Codomain (Coercion a)
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 data Literal
   = Int Integer
@@ -141,7 +143,7 @@ data Literal
   | Float Double
   | LitTrue | LitFalse
   | Unit | RecNil
-  deriving (Eq, Show, Ord)
+  deriving (Eq, Show, Ord, Generic, Hashable)
 
 data Type a
   = ConTy a -- A type constructor
@@ -152,19 +154,19 @@ data Type a
   | ValuesTy [Type a] -- ^ The type of unboxed tuples
   | NilTy -- ^ The type of empty records
   | StarTy -- ^ The type of types
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 pattern ExactRowsTy :: [(Text, Type a)] -> Type a
 pattern ExactRowsTy ts = RowsTy NilTy ts
 
 data BoundTv a = Irrelevant | Relevant a
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 data AnnStmt b a
   = Foreign a (Type a) Text
   | StmtLet (AnnBinding b a)
   | Type a [(a, Type a)]
-  deriving (Eq, Show, Ord, Functor, Generic)
+  deriving (Eq, Show, Ord, Functor, Generic, Hashable)
 
 makeLenses ''AnnArm
 makePrisms ''AnnStmt

--- a/src/Core/Occurrence.hs
+++ b/src/Core/Occurrence.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable, ExplicitNamespaces #-}
+{-# LANGUAGE ScopedTypeVariables, DeriveDataTypeable,
+   ExplicitNamespaces, DeriveGeneric, DeriveAnyClass #-}
 
 {- | Similar to "Core.Free", but also tracking /how/ a variable is
    used. Namely, we annotate variables and bindings with 'Occurrence'.
@@ -24,6 +25,9 @@ import Data.Data
 
 import Text.Pretty.Semantic
 
+import Data.Hashable
+import GHC.Generics
+
 -- | The occurrence of a variable
 data Occurrence
   = Dead        -- ^ This variable is never used
@@ -31,7 +35,7 @@ data Occurrence
   | OnceLambda  -- ^ This variable is used once and is captured by a lambda
   | Multi       -- ^ This variable is used multiple times (or in multiple cases)
   | MultiLambda -- ^ This variable is used multiple times and is captured by a lambda
-  deriving (Show, Eq, Ord, Data)
+  deriving (Show, Eq, Ord, Data, Generic, Hashable)
 
 defOcc :: Occurrence
 defOcc = MultiLambda
@@ -64,7 +68,7 @@ data OccursVar v
   = OccursVar { underlying :: v
               , used :: !Occurrence
               }
-  deriving (Eq, Show, Ord, Data)
+  deriving (Eq, Show, Ord, Data, Generic, Hashable)
 
 instance IsVar a => IsVar (OccursVar a) where
   toVar = toVar . underlying

--- a/src/Core/Optimise/CommonExpElim.hs
+++ b/src/Core/Optimise/CommonExpElim.hs
@@ -54,5 +54,7 @@ cseTerm scope map' (Let (Many vs) body) =
 
 worthIt :: Term a -> Bool
 worthIt Lam{} = False
+worthIt Let{} = False
 worthIt Atom{} = False
+worthIt Match{} = False
 worthIt _ = True

--- a/src/Core/Optimise/CommonExpElim.hs
+++ b/src/Core/Optimise/CommonExpElim.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE ScopedTypeVariables, ViewPatterns #-}
+-- | Eliminate common subexpressions by keeping a hashmap of terms to
+-- binding sites and recursively deduplicating each one-valued let.
+module Core.Optimise.CommonExpElim (csePass) where
+
+import qualified Data.HashMap.Strict as Map
+import qualified Data.VarMap as Vm
+import Data.HashMap.Strict (HashMap)
+
+import Control.Lens
+
+import Core.Optimise
+import Core.Arity
+
+type CseScope a = HashMap (Term a) a
+
+csePass :: forall a. IsVar a => [Stmt a] -> [Stmt a]
+csePass = cseStmt emptyScope where
+  cseStmt :: ArityScope -> [Stmt a] -> [Stmt a]
+  cseStmt scope (x@Foreign{}:xs) = x:cseStmt scope xs
+  cseStmt scope (StmtLet (One b@(v, ty, ex)):xs) =
+    let s' = extendPureLets scope [b]
+     in StmtLet (One (v, ty, cseTerm scope mempty ex)):cseStmt s' xs
+  cseStmt scope (StmtLet (Many bs):xs) =
+    let s' = extendPureLets scope bs
+        bs' = map (\(var, ty, ex) -> (var, ty, cseTerm scope mempty ex)) bs
+     in StmtLet (Many bs'):cseStmt s' xs
+  cseStmt scope (d@(Type _ cs):xs) = d:cseStmt (extendPureCtors scope cs) xs
+  cseStmt _ [] = []
+
+cseTerm :: forall a. IsVar a => ArityScope -> CseScope a -> Term a -> Term a
+cseTerm scope map (Let (One bind@(v, ty, cseTerm scope map -> ex)) body)
+  | Just var <- ex `Map.lookup` map = -- eliminate it
+    cseTerm scope map $ substitute (Vm.singleton (toVar v) (Ref var ty)) body
+  | worthIt ex && isPure scope ex = -- include it for elimination
+    let scope' = extendPureLets scope [bind]
+        map' = Map.insert ex v map
+     in Let (One (v, ty, ex)) (cseTerm scope' map' body)
+  | otherwise = -- carry on
+    Let (One (v, ty, ex)) (cseTerm (extendPureLets scope [bind]) map body)
+cseTerm _ _ x@Atom{} = x
+cseTerm _ _ x@Cast{} = x
+cseTerm _ _ x@App{} = x
+cseTerm scope map (Lam arg body) = Lam arg (cseTerm scope map body)
+cseTerm _ _ x@TyApp{} = x
+cseTerm _ _ x@Values{} = x
+cseTerm _ _ x@Extend{} = x
+cseTerm scope map' (Match ex as) = Match ex (map cseArm as) where
+  cseArm a = a & armBody %~ cseTerm scope map'
+cseTerm scope map' (Let (Many vs) body) =
+  let vs' = map (_3 %~ cseTerm scope map') vs
+      scope' = extendPureLets scope vs'
+   in Let (Many vs') (cseTerm scope' map' body)
+
+worthIt :: Term a -> Bool
+worthIt Lam{} = False
+worthIt Atom{} = False
+worthIt _ = True

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -4,6 +4,7 @@ module Core.Simplify
   ) where
 
 -- import Core.Optimise.Newtype
+import Core.Optimise.CommonExpElim
 import Core.Optimise.DeadCode
 import Core.Optimise.Sinking
 import Core.Optimise.Joinify
@@ -33,6 +34,7 @@ optmOnce = passes where
            , linted "Sinking" $ pure . sinkingPass . tagFreeSet
 
            , linted "Reduce" $ pure . reducePass
+           , linted "CSE" $ pure . csePass
            ]
 
   linted :: Functor f => String -> ([Stmt CoVar] -> f [Stmt CoVar]) -> [Stmt CoVar] -> f [Stmt CoVar]

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -29,11 +29,11 @@ optmOnce = passes where
            , linted "Inline"   inlineVariablePass
 
            , linted "Dead code" $ pure . deadCodePass
-           , linted "Match Join"   matchJoinPass
+           , linted "Match Join"  matchJoinPass
 
            , linted "Sinking" $ pure . sinkingPass . tagFreeSet
 
-           , linted "Reduce" $ pure . reducePass
+           , linted "Reduce #2" $ pure . reducePass
            , linted "CSE" $ pure . csePass
            ]
 
@@ -45,7 +45,7 @@ optmOnce = passes where
 
 -- | Run the optimiser multiple times over the input core.
 optimise :: [Stmt CoVar] -> Namey [Stmt CoVar]
-optimise = go 25 . (runLint "Lower" =<< checkStmt emptyScope) where
+optimise = go 10 . (runLint "Lower" =<< checkStmt emptyScope) where
   go :: Integer -> [Stmt CoVar] -> Namey [Stmt CoVar]
   go k sts
     | k > 0 = go (k - 1) =<< optmOnce sts

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE DeriveGeneric, DeriveDataTypeable, TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric, DeriveDataTypeable, TemplateHaskell,
+   DeriveAnyClass #-}
 
 -- | Core uses one variable type 'CoVar' across all types (terms, types,
 -- coercions). These are identified by a unique number, which allows for
@@ -6,6 +7,8 @@
 module Core.Var where
 
 import qualified Data.Text as T
+import Data.Hashable
+
 import Control.Lens
 import GHC.Generics
 import Text.Pretty.Semantic
@@ -17,7 +20,7 @@ data CoVar =
         , _covarName :: T.Text -- ^ The name of this variable.
         , _covarInfo :: VarInfo -- ^ Additional information about this variable.
         }
-  deriving (Show, Generic, Data)
+  deriving (Show, Generic, Data, Hashable)
 
 instance Eq CoVar where
   (CoVar a _ _) == (CoVar b _ _) = a == b
@@ -33,7 +36,7 @@ data VarInfo
   | TypeConVar
   | TypeVar
   | CastVar
-  deriving (Eq, Show, Ord, Generic, Data)
+  deriving (Eq, Show, Ord, Generic, Data, Hashable)
 
 makeLenses ''CoVar
 makePrisms ''VarInfo
@@ -44,7 +47,7 @@ instance Pretty CoVar where
 -- | Either a 'CoVar' or some alternative representation of it. This is
 -- used to allow functions which may operate on 'CoVar's or annotated
 -- alternatives.
-class (Eq a, Ord a, Pretty a, Show a) => IsVar a where
+class (Hashable a, Eq a, Ord a, Pretty a, Show a) => IsVar a where
   -- | Convert this variable into a 'CoVar'
   toVar :: a -> CoVar
   -- | Build this from a 'CoVar'

--- a/src/Data/VarMap.hs
+++ b/src/Data/VarMap.hs
@@ -9,8 +9,7 @@ module Data.VarMap
   , (<>), mempty
   ) where
 
-import qualified Data.IntMap.Strict as Map
-import qualified Data.IntMap.Merge.Strict as Map
+import qualified Data.HashMap.Strict as Map
 import qualified Data.Text as T
 import qualified Data.List as L
 import Data.Coerce
@@ -21,7 +20,7 @@ import Control.Arrow
 import Core.Var
 
 newtype Map a
-  = Map (Map.IntMap a)
+  = Map (Map.HashMap Int a)
   deriving (Eq, Show, Ord)
   deriving newtype (Semigroup, Monoid, Functor, Foldable)
 
@@ -41,7 +40,7 @@ member :: CoVar -> Map a -> Bool
 member (CoVar x _ _) (Map m) = Map.member x m
 
 findWithDefault :: a -> CoVar -> Map a -> a
-findWithDefault d (CoVar x _ _) (Map m) = Map.findWithDefault d x m
+findWithDefault d (CoVar x _ _) (Map m) = Map.lookupDefault d x m
 
 lookup :: CoVar -> Map a -> Maybe a
 lookup (CoVar x _ _) (Map m) = Map.lookup x m
@@ -56,10 +55,10 @@ singleton :: CoVar -> a ->  Map a
 singleton (CoVar x _ _) v = coerce (Map.singleton x v)
 
 unionSemigroup :: Semigroup a => Map a -> Map a -> Map a
-unionSemigroup (Map l) (Map r) = Map (Map.merge Map.preserveMissing Map.preserveMissing (Map.zipWithMatched (const (<>))) l r)
+unionSemigroup (Map l) (Map r) = Map (Map.unionWith (<>) l r)
 
 foldrWithKey :: (CoVar -> a -> b -> b) -> b -> Map a -> b
 foldrWithKey f b (Map m) = Map.foldrWithKey (f . create) b m
 
-create :: Map.Key -> CoVar
+create :: Int -> CoVar
 create i = CoVar i (T.singleton '?') ValueVar

--- a/src/Data/VarSet.hs
+++ b/src/Data/VarSet.hs
@@ -7,7 +7,7 @@ module Data.VarSet
   , (<>), mempty, isEmpty
   ) where
 
-import qualified Data.IntSet as Set
+import qualified Data.HashSet as Set
 import qualified Data.Text as T
 
 import Core.Var
@@ -15,7 +15,7 @@ import Core.Var
 import Data.Coerce
 
 newtype Set
-  = Set Set.IntSet
+  = Set (Set.HashSet Int)
   deriving (Eq, Show, Ord)
   deriving newtype (Semigroup, Monoid)
 
@@ -32,7 +32,7 @@ member :: CoVar -> Set -> Bool
 member (CoVar x _ _) set = Set.member x (coerce set)
 
 notMember :: CoVar -> Set -> Bool
-notMember (CoVar x _ _) set = Set.notMember x (coerce set)
+notMember (CoVar x _ _) set = not (Set.member x (coerce set))
 
 difference :: Set -> Set -> Set
 difference = coerce Set.difference

--- a/tests/lua/cse.lua
+++ b/tests/lua/cse.lua
@@ -1,0 +1,18 @@
+do
+  local __builtin_unit = {
+    __tag = "__builtin_unit"
+  }
+  local print = print
+  local function Foo (x)
+    return {
+      __tag = "Foo",
+      [1] = x
+    }
+  end
+  local ch = (function ()
+    local x = Foo(1)
+    local cd = print
+    cd(x)
+    return cd(x)
+  end)()
+end

--- a/tests/lua/cse.ml
+++ b/tests/lua/cse.ml
@@ -1,0 +1,12 @@
+external val print : 'a -> unit = "print"
+type foo = Foo of int
+
+let use_foo x y =
+  print x
+  print y
+  ()
+
+let () =
+  let x = Foo 1
+  let y = Foo 1
+  use_foo x y


### PR DESCRIPTION
Pretty simple: We have a hashmap connecting expressions to their binding
sites, which we can use to increase sharing of pure variables.

For instance:

```ocaml
let x = Foo 1 in
let y = Foo 1 in
use x y
```

since x and y's values end up hashing to the same thing, we can
substitute all uses of y (since it's considered later) with a reference
to x, and generate

```ocaml
let x = Foo 1 in
use x x
```