### PR TITLE
Rewrite the Lua codegen

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -163,6 +163,7 @@ library amulet
                      , Types.Infer.Pattern
                      , Types.Infer.Constructor
                      -- Pretty
+                     , Text.Dot
                      , Text.Pretty
                      , Text.Pretty.Ansi
                      , Text.Pretty.Note

--- a/src/Backend/Escape.hs
+++ b/src/Backend/Escape.hs
@@ -75,7 +75,7 @@ pushVar v s = escapeVar (toVar v) where
 -- | Look up the escaped representation of a variable. This is a partial
 -- function and will error if it does not exist.
 getVar :: IsVar a => a -> EscapeScope -> T.Text
-getVar v s = fromMaybe (error ("Cannot find " ++ show v)) (Map.lookup (toVar v) (toEsc s))
+getVar v s = fromMaybe (error ("Cannot find " ++ show v ++ " in escape scope")) (Map.lookup (toVar v) (toEsc s))
 
 -- | Look up the variable for a given input string.
 getEscaped :: IsVar a => T.Text -> EscapeScope -> Maybe a

--- a/src/Backend/Lua.hs
+++ b/src/Backend/Lua.hs
@@ -8,6 +8,10 @@ module Backend.Lua
   , LuaStmt
   ) where
 
+import Control.Monad.State
+
+import Data.Foldable
+
 import Backend.Lua.Postprocess
 import Backend.Lua.Syntax
 import Backend.Lua.Emit
@@ -19,5 +23,5 @@ import Core.Var
 -- | Compile a collection of "Core"'s top-level statements to a Lua
 -- statement
 compileProgram :: IsVar a => [Stmt a] -> LuaStmt
-compileProgram = LuaDo . (unitDef :) . addOperators . emitProgram . tagOccursVar where
+compileProgram = LuaDo . (unitDef :) . addOperators . toList . flip evalState defaultEmitState . emitStmt . tagOccursVar where
   unitDef = LuaLocal [ LuaName "__builtin_unit" ] [ LuaTable [ (LuaString "__tag", LuaString "__builtin_unit") ] ]

--- a/src/Backend/Lua.hs
+++ b/src/Backend/Lua.hs
@@ -17,11 +17,12 @@ import Backend.Lua.Syntax
 import Backend.Lua.Emit
 
 import Core.Occurrence
+import Core.Free
 import Core.Core
 import Core.Var
 
 -- | Compile a collection of "Core"'s top-level statements to a Lua
 -- statement
 compileProgram :: IsVar a => [Stmt a] -> LuaStmt
-compileProgram = LuaDo . (unitDef :) . addOperators . toList . flip evalState defaultEmitState . emitStmt . tagOccursVar where
+compileProgram = LuaDo . (unitDef :) . addOperators . toList . flip evalState defaultEmitState . emitStmt . tagFreeSet . tagOccursVar where
   unitDef = LuaLocal [ LuaName "__builtin_unit" ] [ LuaTable [ (LuaString "__tag", LuaString "__builtin_unit") ] ]

--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -1,447 +1,745 @@
-{-# LANGUAGE OverloadedStrings, ScopedTypeVariables, FlexibleContexts, TupleSections, TemplateHaskell #-}
-
-{-|
-  = The Amulet imperative backend
-
-  The backend is one of the more confusing parts of Amulet (even if not the most
-  complex). Every time I go near it I have to sit down and work out what it's
-  doing, and the confusion has not decreased over time. Consequently, this
-  comment hopes to lay out how the backend is designed.
-
-  One thing to note is that while this currently targets Lua, the same
-  techniques could be applied to most imperative languages. It may be worth
-  defining some generic "imperative IR", which can then be converted to Lua, JS,
-  etc... Anyway, a discussion for another day.
-
-  The backend can be thought of as two separate emitters, handling the toplevel
-  and terms/atoms respectively. Both receive an "escape scope", which ensures
-  variables (especially operators) are valid identifiers, as well as preventing
-  accidental shadowing of variable names.
-
-  == The toplevel emitter
-
-  The toplevel is the simpler of these as there is no fancy handling, we simply
-  loop through each element, push the variables into the escape code and
-  generate the appropriate code. Once all elements have been emitted, we call
-  main with the appropriate number of arguments.*
-
-  When generating lets, we delegate off to the term (or statement) emitter.
-
-  *Less said about this the better. We need to fix our handling of how main is
-   invoked.
-
-  == The expression emitter
-
-  In order to convert or flat ANF into a tree, we walk down the "spine" of the
-  expression tree - the body of let bindings and single-variable matches. For
-  each element on the spine, we pop its dependencies from the stack and push the
-  result back onto the stack (when the result is only used once).
-
-  Most of the time this occurs with no problem. However, there are situations
-  where the variables are used in a different order to the order they are
-  consumed in. Here we generate local variables for the entire stack and then
-  continue execution with an empty one.
-
-  Some expressions are not part of a "run," or are guaranteed to require a
-  statement. These include matches with multiple branches, recursive lets, and
-  record extensions. In these cases, we flush* the expression stack and emit the
-  term.
-
-  Sadly, the generating of the statement list is a little confusing. Most of the
-  generation acts as a WriterT: we prepend onto a list. However, we also keep
-  track of a "return generator". This generates the appropriate code to escape
-  from this statement. In most cases this is just `return`, though may assign to
-  a variable instead.
-
-  Consequently, statement generation is expressed as a ContT [LuaStmt], with the
-  initial continuation acting as the returner.
-
-  *Some terms will pop expressions off the stack before flushing the remainder
-   as the can be emitted inline.
-
--}
-
+{-# LANGUAGE OverloadedStrings, NamedFieldPuns, FlexibleContexts, TupleSections, ViewPatterns, ScopedTypeVariables #-}
 module Backend.Lua.Emit
-  ( emitProgram
-  , emitProgramWith
-  , escapeScope, remapOp, ops
+  ( emitStmt
+  , TopEmitState(..)
+  , defaultEmitState
+  , ops, remapOp, escapeScope
   ) where
 
+import Control.Monad.Reader
 import Control.Monad.State
-import Control.Monad.Cont
-import Control.Lens
+import Control.Arrow (first)
 
 import qualified Data.VarMap as VarMap
+import qualified Data.VarSet as VarSet
+import Data.Sequence ((<|), (|>), Seq)
 import qualified Data.Text as T
+import Data.Functor.Identity
+import Data.Traversable
 import Data.Foldable
 import Data.Triple
 import Data.Maybe
-import Data.List
-import Data.Text (Text)
-
-import Backend.Lua.Syntax
-import Backend.Escape
 
 import Core.Occurrence
 import Core.Builtin
+import Core.Arity
 import Core.Types
 import Core.Core
 import Core.Var
 
-type Returner = [LuaExpr] -> LuaStmt
+import Backend.Lua.Syntax
+import Backend.Escape
 
-data VarEntry v =
-  VarEntry { vVar  :: v
-           , vExpr :: [LuaExpr]
-           , vPure :: Bool
-           }
+-- | A magic variable used to represent the return value
+vReturn :: CoVar
+vReturn = CoVar (-100) "<<ret>>" ValueVar
+
+-- | A node in the  graph of emitted expressions and statements
+--
+-- 'EmittedExpr's should be merged inline into another expression if
+-- doing so does not introduce loops into the graph. Meanwhile one should
+-- consume the 'EmittedStmt' 'emitBound' variables from the statement
+-- instead.
+data EmittedNode a
+  = EmittedExpr
+    { emitExprs :: [LuaExpr]  -- ^ The expression(s) which will be emitted
+    , emitVar   :: a          -- ^ The variable which could be bound. Should only ever be one variable.
+    , emitTy    :: Type a     -- ^ The type of the variable to emit. Primarily used to handle unboxed tuples.
+    , emitBinds :: [a]        -- ^ The variables bound in the statement. Purely used when traversing the dependency
+                              -- graph.
+    , emitDeps  :: VarSet.Set -- ^ The dependencies for this node. Consuming it should assimilate them.
+    }
+  | EmittedStmt
+    { emitStmts :: Seq LuaStmt -- ^ The statements required before this can be evaluated
+    , emitBound :: [LuaVar]    -- ^ The variable(s) bound.
+    , emitBinds :: [a]         -- ^ The variables bound in the statement. Purely used when traversing graphs.
+    , emitDeps  :: VarSet.Set  -- ^ The dependencies for this node. Consuming need not assimilate them.
+    }
+  | EmittedUpvalue
+    { emitBound :: [LuaVar]    -- ^ The variable(s) bound.
+    , emitBinds :: [a]         -- ^ The variable bound in this statement. Purely used when traversing graphs.
+    , emitDeps  :: VarSet.Set  -- ^ An empty set of dependencies for this node
+    }
   deriving (Show)
 
-data EmitState v = EmitState { _eStack  :: [VarEntry v]
-                             , _eEscape :: EscapeScope }
+-- | The graph of all 'EmittedNode's.
+type EmittedGraph a = VarMap.Map (EmittedNode a)
+
+-- | The top-level emitting state. This is substantially simpler than the
+-- more general 'EmitState' as it need node maintain an expression graph.
+data TopEmitState = TopEmitState
+  { topVars   :: VarMap.Map [LuaVar]
+  , topArity  :: ArityScope
+  , topEscape :: EscapeScope
+  }
   deriving (Show)
 
-makeLenses ''EmitState
+-- | The current state for the expression/term emitter. This is thread
+-- through a 'MonadState' instance.
+data EmitState a = EmitState
+  { emitGraph  :: EmittedGraph a
+  , emitPrev   :: VarSet.Set
+  , emitEscape :: EscapeScope
+  }
+  deriving (Show)
 
-type ExprContext v a = ContT [LuaStmt] (State (EmitState v)) a
+-- | The current scope for the expression/term emitter. This is thread
+-- through a 'MonadReader' instance.
+newtype EmitScope a = EmitScope
+  { emitArity :: ArityScope
+  }
+  deriving (Show)
 
--- | Convert a list of core top-levels into a collection of Lua
--- statements using the default scope.
-emitProgram :: forall a. Occurs a => [Stmt a] -> [LuaStmt]
-emitProgram = fst . emitProgramWith escapeScope
+-- | Controls how one of more variables should be returned from a
+-- statement
+data EmitYield a
+  = YieldReturn -- ^ Return the expression(s) using 'LuaReturn'
+  | YieldDiscard -- ^ Discard this expression
+  | YieldStore [LuaVar] -- ^ Assign this expression(s) to these variables
+  | YieldDeclare a (Type a) -- ^ Declare this variable
+  deriving (Show)
 
--- | Convert a list of core top-levels into a collection of Lua
--- statements using the provided scope.
-emitProgramWith :: forall a. Occurs a => EscapeScope -> [Stmt a] -> ([LuaStmt], EscapeScope)
-emitProgramWith esc = flip runState esc . emitProg where
-  emitProg :: MonadState EscapeScope m => [Stmt a] -> m [LuaStmt]
-  emitProg (Foreign n' t s:xs)
-    | arity t > 1 = do
-        n <- state (pushVar n')
-        let ags = map LuaName $ take (arity t) alpha
-            mkF (a:ag) bd = LuaFunction [a] [LuaReturn [mkF ag bd]]
-            mkF [] bd = bd
+-- | The state for emitting a single node.
+--
+-- This is a wrapper for 'EmitState', but also tracking dependencies for
+-- this node. One generally uses 'runNES' in order to evaluate this.
+data NodeEmitState a = NES
+  { nodeState :: EmitState a
+  , nodeDeps  :: VarSet.Set
+  }
 
-        xs' <- emitProg xs
+-- | The default (initial) state for the emitter.
+defaultEmitState :: TopEmitState
+defaultEmitState = TopEmitState mempty emptyScope escapeScope
 
-        pure $ LuaLocal [LuaName (T.cons '_' n)] [LuaBitE s]
-             : LuaLocal [LuaName n]
-                [mkF ags
-                  (LuaCall (LuaRef (LuaName (T.cons '_' n)))
-                    (map LuaRef ags))]
-             : xs'
+liftedGraph :: forall a m.
+               ( IsVar a
+               , MonadReader (EmitScope a) m
+               , MonadState (EmitState a) m )
+            => VarSet.Set -> m (EmittedGraph a)
+liftedGraph = VarSet.foldr liftNode (pure mempty) where
+  liftNode :: CoVar -> m (EmittedGraph a) -> m (EmittedGraph a)
+  liftNode v m = do
+    n <- emitVarBinds v
+    VarMap.insert v (EmittedUpvalue n [fromVar v] mempty) <$> m
 
-    | otherwise = do
-        n <- state (pushVar n')
-        (:) (LuaLocal [LuaName n] [LuaBitE s]) <$> emitProg xs
+-- | Emit an expression within a child scope.
+--
+-- This will not modify the existing scope/state in any way, it's just a
+-- convenience function to avoid having to extract values manually.
+emitLifted :: ( Occurs a
+            , MonadReader (EmitScope a) m
+            , MonadState (EmitState a) m )
+         => EmitYield a -> Term a
+         -> m (Seq LuaStmt)
+emitLifted yield term = do
+  graph <- liftedGraph (freeIn term)
+  scope <- ask
+  escape <- gets emitEscape
+  pure . fst $ emitTerm scope escape graph yield term
 
-  emitProg (StmtLet (One (v, _, e)):xs) = do
-    v' <- state (pushVar v)
-    s <- get
-    (mkBind LuaLocal v' (iife (emitStmt s LuaReturn e)):)
-      <$> emitProg xs
-  emitProg (StmtLet (Many vs):xs) = do
-    vs' <- traverse (first3A (state . pushVar)) vs
-    s <- get
-    ((LuaLocal (map (LuaName . fst3) vs') []
-       : concatMap (\(v, _, e) -> emitStmt s (LuaAssign [LuaName v]) e) vs')++)
-      <$> emitProg xs
-  emitProg (Type _ cs:xs) = (++) <$> traverse emitConstructor cs <*> emitProg xs
-  emitProg [] = pure []
+-- | Emit a term within the provided context.
+--
+-- This builds up a graph of expressions/statements, then performs a
+-- topological sort on the resulting nodes.
+emitTerm :: forall a. Occurs a
+         => EmitScope a -> EscapeScope -> EmittedGraph a
+         -> EmitYield a -> Term a
+         -> (Seq LuaStmt, [LuaVar])
+emitTerm scope esc vars yield term =
+  let (bound, EmitState { emitGraph = graph, emitPrev = prev })
+        = flip runReader scope
+        . flip runStateT EmitState
+          { emitGraph  = vars
+          , emitPrev   = mempty
+          , emitEscape = esc
+          }
+        $ emitExpr (fromVar vReturn) yield term >> emitVarBinds (fromVar vReturn)
 
-  emitConstructor :: MonadState EscapeScope m => (a, Type a) -> m LuaStmt
-  emitConstructor (var, ty)
-    | arity ty == 0 = do
-        var' <- state (pushVar var)
-        pure $ LuaLocal [LuaName var'] [LuaTable [(LuaString "__tag", LuaString var')]]
-    | otherwise = do
-        var' <- state (pushVar var)
-        pure $ LuaLocal [LuaName var'] [LuaFunction
-                                         [LuaName "x"]
-                                        [LuaReturn [LuaTable [ (LuaString "__tag", LuaString var')
-                                                             , (LuaInteger 1, LuaRef (LuaName "x"))]]]]
+  in (fst (flushGraph vReturn prev graph), bound)
+  where
+    flushGraph :: CoVar -> VarSet.Set -> EmittedGraph a
+               -> (Seq LuaStmt, EmittedGraph a)
+    flushGraph var extra g =
+      case VarMap.lookup var g of
+        Nothing -> (mempty, g)
+        Just node ->
+          let
+            stmts = case node of
+              EmittedUpvalue{} -> mempty
+              EmittedStmt { emitStmts = s } -> s
+              EmittedExpr { emitExprs = es } -> foldMap asStmt es
 
-  alpha :: [Text]
-  alpha = map T.pack ([1..] >>= flip replicateM ['a'..'z'])
+            -- Remove this from the graph
+            g' = foldr (VarMap.delete . toVar) g (emitBinds node)
 
+          in first (<>stmts) $ VarSet.foldr
+               (\v (s, g) -> first (s<>) (flushGraph v mempty g))
+               (mempty, g') (emitDeps node <> extra)
 
-pushScope :: IsVar a => MonadState (EmitState a) m => a -> m Text
-pushScope v = state (\s -> let (v', s') = pushVar v (s ^. eEscape) in (v', set eEscape s' s))
+-- | Emit a single expression within the current context
+--
+-- This walks down the expression spine (lets) until it finds
+-- some leaf expression. These are compiled based on the current graph,
+-- their dependencies analysed, and they are then inserted into the
+-- expression/statement graph.
+--
+-- Most of the code for that is performed using 'withinExpr', but some
+-- non-trivial terms (record extensions, matches) roll their own as we
+-- generate statements instead.
+emitExpr :: ( Occurs a
+            , MonadReader (EmitScope a) m
+            , MonadState (EmitState a) m )
+         => a -> EmitYield a -> Term a
+         -> m ()
 
-pushEntry :: IsVar a => MonadState (EmitState a) m => VarEntry a -> m (Text, [LuaExpr])
-pushEntry v = (,vExpr v) <$> pushScope (vVar v)
+emitExpr var yield (Let (One (v, ty, e)) r) = do
+  let yield' = if usedWhen v == Dead then YieldDiscard else YieldDeclare v ty
+  emitExpr v yield' e
+  local (\s -> s { emitArity = extendPureLets (emitArity s) [(v, ty, e)] }) $
+    emitExpr var yield r
 
-emitLit :: Literal -> LuaExpr
-emitLit (Int x)   = LuaInteger (fromIntegral x)
-emitLit (Float x) = LuaNumber x
-emitLit (Str str) = LuaString str
-emitLit LitTrue   = LuaTrue
-emitLit LitFalse  = LuaFalse
-emitLit Unit      = LuaRef (LuaName "__builtin_unit") -- evil!
-emitLit RecNil    = LuaTable []
+emitExpr var yield (Let (Many vs) r) =
+  local (\s -> s { emitArity = extendPureLets (emitArity s) vs }) $ do
+    binds <- traverse (\(v, ty, _) -> (v,) <$> genVars pushScope v ty) vs
+    stmt <- traverse (\((_, _, e), (_, v')) -> emitLifted (YieldStore v') e) (zip vs binds)
 
-emitAtom :: Occurs a => Atom a -> ExprContext a [LuaExpr]
-emitAtom (Lit l) = pure [emitLit l]
-emitAtom (Ref v _) = ContT $ \next -> do
-  xs <- use eStack
-  case break ((==toVar v) . toVar . vVar) xs of
-    -- If we're pure, or we're preceded by pure computations then we're OK to emit directly.
-    (before, VarEntry { vExpr = e, vPure = p }:xs') | p || all vPure before -> do
-      assign eStack (before ++ xs')
-      next e
+    graph <- gets emitGraph
+    prev  <- gets emitPrev
+    arity <- asks emitArity
+    let stmts = LuaLocal (foldMap snd binds) [] <| mconcat stmt
+        p = all (isPure arity . thd3) vs
+        vss = VarSet.fromList (map (toVar . fst3) vs)
 
-    -- If we're not in the scope at all, emit the variable
-    _ | all ((/= toVar v) . toVar . vVar) xs -> do
-      v' <- gets (getVar v . view eEscape)
-      next [LuaRef (LuaName v')]
+        -- We depend on the previous node (if impure), all free variables and
+        -- all other nodes within the binding group.
+        deps = (if p then mempty else prev)
+               <> VarSet.filter (`VarMap.member` graph) (foldMap (freeIn . thd3) vs)
+               `VarSet.difference` vss
 
-    -- If we're in the list head, then flush everything and return
-    _ -> do
-      assign eStack []
-      vs <- traverse pushEntry xs
-      v' <- gets (getVar v . view eEscape)
-      flip mkLets vs <$> next [LuaRef (LuaName v')]
+        -- Add us to every node
+        vs' = map fst3 vs
+        graph' = foldr (\(v, v') -> VarMap.insert (toVar v) (EmittedStmt stmts v' vs' deps)) graph binds
 
-flushStmt :: Occurs a => [LuaStmt] -> ExprContext a ()
-flushStmt extra = ContT $ \next -> do
-  xs <- use eStack >>= traverse pushEntry
-  assign eStack []
-  stmts <- next ()
-  pure (mkLets (extra ++ stmts) xs)
+    -- Update the graph and impure set if needed
+    modify (\s -> s { emitGraph = graph'
+                    , emitPrev = if p then prev else vss })
 
-emitTerm :: forall a. Occurs a => Term a -> ExprContext a [LuaExpr]
-emitTerm (Atom a) = emitAtom a
+    -- Emit the body within the existing context
+    emitExpr var yield r
 
-emitTerm (App f e) = do
-  e' <- emitAtom e
-  [f'] <- emitAtom f
+emitExpr var yield (Match test [Arm { _armPtrn = p, _armBody = body, _armVars = vs }])
+  | [(v, _)] <- filter (doesItOccur . fst) vs
+  , usedWhen v == Once
+  = do
+      -- Push our pattern into the scope
+      withinExpr v (YieldDeclare v (getTy v)) (Atom test) $ do
+        test' <- emitAtom test
+        pure . snd . head $ patternBindings p test'
 
-  esc <- use eEscape
-  pure . pure $ case f' of
-    -- Attempt to reduce applications of binary functions to the operators
-    -- themselves.
-    LuaRef (LuaName op)
-      | Just op' <- getEscaped op esc, Just opv <- VarMap.lookup (op' :: CoVar) ops
-      , [l, r] <- e'
-      -> LuaBinOp l opv r
-
-    _ -> LuaCall f' e'
-
-emitTerm (Lam (TermArgument v _) e) = do
-  (v', s) <- uses eEscape (pushVar v) -- Note this doesn't modify the scope, only extends it
-  pure [LuaFunction [LuaName v'] (emitStmt s LuaReturn e)]
-emitTerm (Lam TypeArgument{} e) = emitTerm e
-
-emitTerm (TyApp f _) = emitAtom f
-emitTerm (Cast f _) = emitAtom f
-
-emitTerm (Extend (Lit RecNil) fs) =
-  {-
-    Record literals are nice and simple to generate, and can just be
-    emitted as expressions.
-  -}
-  pure . LuaTable <$> foldrM emitRow [] fs
-  where emitRow (f, _, e) es = (:es) . (LuaString f,) . head <$> emitAtom e
-
-emitTerm (Extend tbl exs) = do
-  {-
-    Record extensions have to be emitted as a statement, and so we flush our
-    context and continue compilation.
-  -}
-  exs' <- foldrM emitRow [] exs
-  [tbl'] <- emitAtom tbl
-
-  flushStmt ([ LuaLocal [old, new] [tbl', LuaTable []]
-             , LuaFor [k, v] [LuaCall (LuaRef pairs) [LuaRef old]]
-               [LuaAssign [LuaIndex (LuaRef new) (LuaRef (LuaName k))] [LuaRef (LuaName v)]] ] ++ exs')
-  pure [LuaRef new]
-
-  where old = LuaName (T.pack "__o")
-        new = LuaName (T.pack "__n")
-        k = T.pack "k"
-        v = T.pack "v"
-        pairs = LuaName (T.pack "pairs")
-
-        emitRow (f, _, e) es = (:es) . LuaAssign [LuaIndex (LuaRef new) (LuaString f)] <$> emitAtom e
-
-emitTerm (Values ts) = foldrM (\x xs -> (:xs) . head <$> emitAtom x) [] ts
-
-emitTerm (Let (One (x, _, e)) body)
-  | Match _ (_:_:_) <- e = do
-      {-
-        This is a match with multiple branches. We declare our variable
-        beforehand, flush all existing variables and emit both branches before
-        continuing.
-      -}
-      x' <- pushScope x
-      flushStmt [ LuaLocal [LuaName x'] [] ]
-      s <- use eEscape
-      flushStmt (emitStmt s (mkBind LuaAssign x') e)
-      emitTerm body
-
-  | usedWhen x == Once = do
-      {-
-        A variable which is only used once can be pushed to the expression
-        stack.
-      -}
-      e' <- emitTerm e
-      modifying eStack (VarEntry x e' False:)
-      emitTerm body
-
-  | usedWhen x == Dead = do
-      {-
-        Are we never used? Then we can safely emit the body without a care in
-        the world.
-      -}
-      e' <- emitTerm e
-      traverse_ (flushStmt . asStmt) e'
-      emitTerm body
+      -- Emit the body within the existing context
+      emitExpr var yield body
 
   | otherwise = do
-      {-
-        Otheriwse we've got a let binding which doesn't branch, then we can emit
-        it as a normal local.
-      -}
-      e' <- emitTerm e -- TODO: Fix my emission of tuples
-      x' <- pushScope x
-      flushStmt [mkBind LuaLocal x' e']
-      emitTerm body
+    ps <- patternBindings p <$> emitAtomMany test
 
-  where asStmt (LuaTable fs) = concatMap (asStmt . snd) fs
-        asStmt (LuaBinOp a _ b) = asStmt a ++ asStmt b
-        asStmt (LuaCall f e) = [ LuaCallS f e ]
-        asStmt _ = []
+    let deps = freeInAtom test
+    modify (\s -> s { emitGraph = foldr (\(v, es) ->
+      VarMap.insert (toVar v) EmittedExpr { emitExprs = es
+                                          , emitVar = v
+                                          , emitTy = getTy v
+                                          , emitBinds = [v]
+                                          , emitDeps = deps }) (emitGraph s) ps})
 
-emitTerm (Let (Many bs) body) = do
-  {-
-    Lets which declare mutually recursive variables are relatively trivial to
-    deal with: just emit the definitions, declare them and continue.
-  -}
-  bs' <- traverse ((LuaName<$>) . pushScope . fst3) bs
-  flushStmt [ LuaLocal bs' [] ]
-  traverse_ emitLet bs
-  emitTerm body
-  where emitLet (v, _, e) = do
-          s <- use eEscape
-          flushStmt (emitStmt s (mkBind LuaAssign (getVar v s)) e)
+    -- Emit the body within the existing context
+    emitExpr var yield body
 
-emitTerm (Match test branches)
-  | [Arm { _armPtrn = p, _armBody = body, _armVars = vs}] <- branches
-  , [(x, _)] <- filter ((/=Dead) . usedWhen . fst) vs
-  , usedWhen x == Once
-  , isntTuple p
-  = do
-      test' <- emitAtom test
-      -- Just push the bindings onto the stack
-      modifying eStack (withMatch False (patternBindings p test')++)
+  where getTy v = maybe (error "Cannot find pattern variable") snd (find ((==v) . fst) vs)
 
-      emitTerm body
+emitExpr var yield (Match test arms) = do
+  (yield', stmt, bound) <- case yield of
+    YieldReturn -> pure (YieldReturn, mempty, mempty)
+    YieldDiscard -> pure (YieldDiscard, mempty, mempty)
+    YieldStore vs -> pure (YieldStore vs, mempty, vs)
+    YieldDeclare v ty -> do
+      v' <- genVars pushScope v ty
+      pure (YieldStore v', pure (LuaLocal v' []), v')
 
-  | [Arm { _armPtrn = p, _armBody = body }] <- branches =  do
-      {-
-        Matches with a single arm do not require a branch, so we simply flush
-        the stack and declare whatever variables are needed. It might be
-        possible to improve this in the future: if we know the test is an
-        already popped variable then we could just push them onto the stack.
-        It's worth noting that there are some "obvious" cases not handled here
-        (such as all variables being unused) as the optimiser should have
-        nobbled them already.
-      -}
-      flushStmt []
-      test' <- emitAtom test
-
-      let (once, multi) = partition ((==Once) . usedWhen . fst) (patternBindings p test')
-
-      -- Declare any variable used multiple times (or hoisted into a lambda)
-      multi' <- traverse (firstA pushScope) multi
-      unless (null multi') (flushStmt (map (uncurry (mkBind LuaLocal)) multi'))
-
-      -- Push any variable used once onto the stack
-      modifying eStack (withMatch True once++)
-
-      emitTerm body
-
-  | (ifs@Arm { _armPtrn = PatLit LitTrue } :
-     els@Arm { _armPtrn = PatLit LitFalse } :_) <- branches = do
+  (deps, body) <- case arms of
+    (Arm { _armPtrn = PatLit LitTrue,  _armBody = ifs } :
+     Arm { _armPtrn = PatLit LitFalse, _armBody = els } :_) -> do
       {-
         Whilst this may seem a little weird special casing this, as we'll
         generate near equivalent code in the general case, it does allow us to
         merge the test with the definition, as we know it'll only be evaluated
         once.
       -}
-      [test'] <- emitAtom test
-      flushStmt[]
-      ContT $ \next -> do
-        (_, ifs') <- emitArm [test'] next ifs
-        (_, els') <- emitArm [test'] next els
-        pure [ LuaIfElse [ (test', ifs')
-                         , (LuaTrue, els') ] ]
+      (deps, test') <- runNES (freeInAtom test) (emitAtomS test)
 
-  | (els@Arm { _armPtrn = PatLit LitFalse } :
-     ifs@Arm { _armPtrn = PatLit LitTrue } :_) <- branches = do
+      ifs' <- emitLifted yield' ifs
+      els' <- emitLifted yield' els
+      pure (deps, LuaIf test' (toList ifs') (toList els'))
+
+    (Arm { _armPtrn = PatLit LitFalse, _armBody = els } :
+     Arm { _armPtrn = PatLit LitTrue,  _armBody = ifs } :_) -> do
       {-
         As above, but testing against `not EXPR`. In this case we just flip the
         two branches
-       -}
-      [test'] <- emitAtom test
-      flushStmt[]
-      ContT $ \next -> do
-        (_, ifs') <- emitArm [test'] next ifs
-        (_, els') <- emitArm [test'] next els
-        pure [ LuaIfElse [ (test', ifs')
-                         , (LuaTrue, els') ] ]
+      -}
+      (deps, test') <- runNES (freeInAtom test) (emitAtomS test)
 
-  | otherwise = do
+      ifs' <- emitLifted yield' ifs
+      els' <- emitLifted yield' els
+      pure (deps, LuaIf test' (toList ifs') (toList els'))
+
+    _ -> do
       {-
         In the case of the general branch, we will probably be consuming the
         pattern multiple times, and so we need to emit it as a variable.
       -}
-      flushStmt []
-      test' <- emitAtom test
-      ContT $ \next -> pure . LuaIfElse <$> traverse (emitArm test' next) branches
+      test' <- emitAtomMany test
+      (freeInAtom test,) . LuaIfElse <$> for arms (genBranch test' yield')
 
-  where withMatch p = map (\(a, b) -> VarEntry a b p)
+  modify (\s -> s
+    { emitGraph = VarMap.insert (toVar var) EmittedStmt
+        { emitStmts = stmt |> body
+        , emitBound = bound
+        , emitBinds = [var]
+        , emitDeps  = deps <> foldMap (freeIn . _armBody) arms <> emitPrev s
+        } (emitGraph s)
+    -- For the time being, we just assume this expression is impure.
+    , emitPrev = VarSet.singleton (toVar var)
+  })
 
-        isntTuple PatValues{} = False
-        isntTuple _ = True
+  where
+    getTy vs v = maybe (error "Cannot find pattern variable") snd (find ((==v) . fst) vs)
 
-emitStmt :: Occurs a => EscapeScope -> Returner -> Term a -> [LuaStmt]
-emitStmt s r term = evalState (runContT (emitTerm term) finish) (EmitState [] s) where
-  finish x = mkLets [r x] <$> (traverse pushEntry =<< use eStack)
+    genBranch test yield' Arm { _armPtrn = p, _armBody = b, _armVars = vs } = do
+      graph <- liftedGraph (freeIn b)
+      scope <- ask
+      escape <- gets emitEscape
 
-iife :: [LuaStmt] -> [LuaExpr]
-iife [LuaReturn v] = v
-iife b = [LuaCall (LuaFunction [] b) []]
+      -- We emit every pattern as an upvalue
+      let patDeps = VarSet.singleton (toVar var)
+      graph' <- foldrM (\(v, expr) g -> do
+        node <- if usedWhen v == Once
+                then pure $ EmittedExpr expr v (getTy vs v)
+                else uncurry EmittedStmt <$> genDeclare pushScope var (getTy vs v) expr
+        pure (VarMap.insert (toVar v) (node [v] patDeps) g))
+        graph (patternBindings p test)
 
-mkLets :: [LuaStmt] -> [(Text, [LuaExpr])] -> [LuaStmt]
-mkLets = foldl (\stmts (v, b) -> mkBind LuaLocal v b : stmts)
+      let (b', _) = emitTerm scope escape graph' yield' b
+      pure (patternTest escape p test, toList b')
 
-mkBind :: ([LuaVar] -> [LuaExpr] -> LuaStmt) -> Text -> [LuaExpr] -> LuaStmt
-mkBind f v [] = f [LuaName v] [LuaNil]
-mkBind f v [e] = f [LuaName v] [e]
-mkBind f v e = f (zipWith (\i _ -> LuaName (v <> T.pack (show i))) [1::Int ..] e) e
+-- Trivial terms. These will just be emitted inline.
+emitExpr var yield t@(Atom x)    = withinExpr var yield t $ emitAtom x
+emitExpr var yield t@(TyApp x _) = withinExpr var yield t $ emitAtom x
+emitExpr var yield t@(Cast x _)  = withinExpr var yield t $ emitAtom x
 
-foldAnd :: [LuaExpr] -> LuaExpr
-foldAnd = foldl1 k where
-  k l r
-    | r == LuaTrue = l
-    | l == LuaTrue = r
-    | r == LuaFalse || l == LuaFalse = LuaFalse
-    | otherwise = LuaBinOp l "and" r
+emitExpr var yield t@(App f e) = withinExpr var yield t $ do
+  e' <- emitAtom e
+  f' <- emitAtomS f
 
-patternTest :: forall a. Occurs a => EscapeScope -> Pattern a -> [LuaExpr] ->  LuaExpr
-patternTest _ (Capture _ _) _       = LuaTrue
-patternTest _ (PatLit RecNil) _     = LuaTrue
-patternTest _ (PatLit l)  [vr]      = LuaBinOp (emitLit l) "==" vr
-patternTest s (PatExtend p rs) [vr] = foldAnd (patternTest s p [vr] : map test rs) where
-  test (var', pat) = patternTest s pat [LuaRef (LuaIndex vr (LuaString var'))]
-patternTest s (Constr con) [vr]    = foldAnd [tag s con vr]
-patternTest s (Destr con p) [vr]   = foldAnd [tag s con vr, patternTest s p [LuaRef (LuaIndex vr (LuaInteger 1))]]
-patternTest s (PatValues ps) vr   = foldAnd (zipWith (\p v -> patternTest s p [v]) ps vr)
-patternTest _ _ _ = undefined
+  esc <- gets (emitEscape . nodeState)
+  pure
+    [ case f' of
+        -- Attempt to reduce applications of binary functions to the operators
+        -- themselves.
+        LuaRef (LuaName op)
+          | Just op' <- getEscaped op esc, Just opv <- VarMap.lookup (op' :: CoVar) ops
+          , [l, r] <- e'
+            -> LuaBinOp l opv r
+        _ -> LuaCall f' e' ]
 
-tag :: Occurs a => EscapeScope -> a -> LuaExpr -> LuaExpr
-tag scp con vr = LuaBinOp (LuaRef (LuaIndex vr (LuaString "__tag"))) "==" (LuaString (getVar con scp))
+emitExpr var yield (Lam TypeArgument{} b) = emitExpr var yield b
+
+emitExpr var yield t@(Lam (TermArgument v ty) e) = do
+  scope <- ask
+  graph <- liftedGraph (freeIn t)
+  escape <- gets emitEscape
+
+  let (v', escape') = pushVar v escape
+      Identity vs = genVars (const (pure v')) v ty
+      graph' = VarMap.insert (toVar v) (EmittedUpvalue vs [v] mempty) graph
+
+      term :: [LuaExpr] = pure . LuaFunction vs . toList . fst $ emitTerm scope escape' graph' YieldReturn e
+  withinExpr var yield t (pure term)
+
+emitExpr var yield t@(Values xs) =
+  {-
+    There really isn't much we can do as far as unboxed tuples go. We
+    just build up a list of all dependent expressions and statement.
+  -}
+  withinExpr var yield t $
+    foldrM (\e es -> (:es) <$> emitAtomS e) mempty xs
+
+emitExpr var yield t@(Extend (Lit RecNil) fs) =
+  {-
+    Record literals are nice and simple to generate, and can just be
+    emitted as expressions.
+
+    TODO: Choose an optimal ordering of expressions
+  -}
+  withinExpr var yield t $
+    pure . LuaTable <$> foldrM emitRow mempty fs
+  where emitRow (f, _, e) es = (:es) . (LuaString f,) <$> emitAtomS e
+
+emitExpr var yield t@(Extend tbl exs) = do
+  {-
+    Record extensions have to be emitted as a statement. We build up a
+    statement list first, and then.
+
+    TODO: Choose an optimal ordering of expressions and potentially
+    inline some statements.
+  -}
+
+  (deps, node) <- runNES (freeIn t) $ case yield of
+    YieldDiscard -> do
+      exs' <- traverse (emitAtom . thd3) exs
+      tbl' <- emitAtom tbl
+      pure $ EmittedStmt (foldMap (foldMap asStmt) (tbl':exs')) []
+
+    YieldStore vs -> do
+      let vs' = head vs
+      exs' <- foldrM (emitRow vs') mempty exs
+      tbl' <- emitAtomS tbl
+      pure $ EmittedStmt (LuaAssign vs [LuaTable []] <| emitCopy vs' tbl' <> exs') vs
+
+    YieldReturn -> do
+      let vs' = LuaName (T.pack "__n")
+      exs' <- foldrM (emitRow vs') mempty exs
+      tbl' <- emitAtomS tbl
+      pure $ EmittedStmt (LuaLocal [vs'] [LuaTable []] <| emitCopy vs' tbl' <> exs') []
+
+    YieldDeclare var' _ -> do
+      vs' <- LuaName <$> pushScope' var'
+      exs' <- foldrM (emitRow vs') mempty exs
+      tbl' <- emitAtomS tbl
+      pure $ EmittedStmt (LuaLocal [vs'] [LuaTable []] <| emitCopy vs' tbl' <> exs') [vs']
+
+  pushGraph var (node [var] deps)
+
+  where
+    k = T.pack "k"
+    v = T.pack "v"
+    pairs = LuaName (T.pack "pairs")
+
+    emitRow var (f, _, e) es = (<|es) . LuaAssign [LuaIndex (LuaRef var) (LuaString f)] <$> emitAtom e
+
+    emitCopy var (LuaRef v@LuaName{}) = pure (copy var v)
+    emitCopy var tbl =
+      let old = LuaName (T.pack "__o")
+      in LuaLocal [old] [tbl] <| copy var old <| mempty
+
+    copy var tbl =
+      LuaFor [k, v] [LuaCall (LuaRef pairs) [LuaRef tbl]]
+         [LuaAssign [LuaIndex (LuaRef var) (LuaRef (LuaName k))] [LuaRef (LuaName v)]]
+
+runNES :: ( MonadReader (EmitScope a) m
+          , MonadState (EmitState a) m )
+       => VarSet.Set -> StateT (NodeEmitState a) m b
+       -> m (VarSet.Set, b)
+runNES deps m = do
+  s <- get
+  (a, NES s' deps') <- runStateT m (NES s deps)
+  put s'
+  pure (deps', a)
+
+withinExpr :: ( Occurs a
+            , MonadReader (EmitScope a) m
+            , MonadState (EmitState a) m )
+         => a -> EmitYield a -> Term a
+         -> StateT (NodeEmitState a) m [LuaExpr]
+         -> m ()
+withinExpr var yield term m = do
+  ari <- asks emitArity
+  prev <- gets emitPrev
+
+  let p = isPure ari term
+      deps = freeIn term <> (if p then mempty else prev)
+  (deps', result) <- runNES deps m
+
+  -- Update the pure set if needed
+  unless p (modify (\s -> s { emitPrev = VarSet.singleton (toVar var) }))
+
+  node <- case yield of
+    YieldDeclare v ty
+      | usedWhen v == Once
+      -> pure $ EmittedExpr result v ty
+    _ -> uncurry EmittedStmt <$> genYield yield result
+
+  pushGraph var (node [var] deps')
+
+emitAtomS :: ( IsVar a
+             , MonadState (NodeEmitState a) m)
+          => Atom a
+          -> m LuaExpr
+emitAtomS a = (\[x] -> x) <$> emitAtom a
+
+emitAtom :: forall a m.
+            ( IsVar a
+            , MonadState (NodeEmitState a) m)
+         => Atom a
+         -> m [LuaExpr]
+emitAtom (Lit l) = pure [emitLit l]
+emitAtom (Ref (toVar -> v) _) = do
+  existing <- gets (VarMap.lookup v . emitGraph . nodeState)
+  case existing of
+    -- Statements and upvalues are easy: the dependency is already in the
+    -- graph so we don't need to do any checks.
+    Nothing -> pure . LuaRef . LuaName <$> gets (getVar v . emitEscape . nodeState)
+    Just EmittedStmt { emitBound = vs } -> pure (map LuaRef vs)
+    Just EmittedUpvalue { emitBound = vs } -> pure (map LuaRef vs)
+
+    Just (EmittedExpr expr var ty binds deps) -> do
+      s <- get
+      let var' = toVar var
+          testEmitGraph' = VarMap.delete var' (emitGraph . nodeState $ s)
+          deps' = VarSet.delete var' . VarSet.union deps . nodeDeps $ s
+      case hasLoop (VarSet.singleton var') deps' testEmitGraph' of
+        Nothing -> do
+          (stmts, vs) <- genDeclare pushScope' var ty expr
+          let existing' = EmittedStmt { emitStmts = stmts
+                                      , emitBound = vs
+                                      , emitBinds = binds
+                                      , emitDeps  = deps
+                                      }
+              emitted' = VarMap.insert var' existing' . emitGraph . nodeState $ s
+          -- TODO: Maybe convert to lenses?
+          modify (\s -> s { nodeState = (nodeState s) { emitGraph = emitted' } })
+          pure (map LuaRef vs)
+        Just{} -> do
+          modify (\s -> s { nodeDeps = deps'
+                          , nodeState = (nodeState s) { emitGraph = testEmitGraph' }
+                          })
+          pure expr
+    where
+      -- | Detect if the @emitted@ has a loop
+      --
+      -- TODO: Convert this to a breadth first search - loops are
+      -- /probably/ going to be close to the start so there's no point
+      -- looping up to the top of the expression tree.
+      hasLoop :: VarSet.Set -- ^ The set of nodes on the visiting stack
+              -> VarSet.Set -- ^ The set of nodes we're about to visit
+              -> EmittedGraph a -- ^ A map of nodes and their edges which have not been visited
+              -> Maybe (EmittedGraph a) -- ^ The remaining nodes/edges which have not been visited
+      hasLoop visiting toVisit emitted = VarSet.foldr (\v emitted ->
+        -- Effectively foldrM, but we don't have an instance for it.
+        case emitted of
+          Nothing -> Nothing
+          Just x -> hasLoop' visiting v x) (Just emitted) toVisit
+
+      hasLoop' :: VarSet.Set -> CoVar -> EmittedGraph a
+              -> Maybe (EmittedGraph a)
+      hasLoop' visiting v remaining =
+        if VarSet.member v visiting then Nothing
+        else case VarMap.lookup v remaining of
+               Nothing -> Just remaining
+               Just e -> hasLoop (VarSet.insert v visiting)
+                                 (emitDeps e)
+                                 (foldr (VarMap.delete . toVar) remaining (emitBinds e))
+
+-- | A variant of 'emitAtom' which always binds expressions.
+--
+-- This is suitable for when something is used many times, even when not
+-- annotated as such (hence the name).
+emitAtomMany :: forall a m.
+                ( IsVar a
+                , MonadState (EmitState a) m)
+             => Atom a
+             -> m [LuaExpr]
+emitAtomMany (Lit l) = pure [emitLit l]
+emitAtomMany (Ref v _) = map LuaRef <$> emitVarBinds (toVar v)
+
+-- | Emit the appropriate bindings for a variable.
+--
+-- This unconditionally promotes an expression to a statement, returning
+-- which variables it was bound to.
+emitVarBinds :: forall a m.
+                ( IsVar a
+                , MonadState (EmitState a) m)
+             => CoVar -> m [LuaVar]
+emitVarBinds v = do
+  existing <- gets (VarMap.lookup v . emitGraph)
+  case existing of
+    -- Statements and upvalues are easy: the dependency is already in the
+    -- graph so we don't need to do any checks.
+    Nothing -> pure . LuaName <$> gets (getVar v . emitEscape)
+    Just EmittedStmt { emitBound = vs } -> pure vs
+    Just EmittedUpvalue { emitBound = vs } -> pure vs
+    Just (EmittedExpr expr var ty binds deps) -> do
+      (stmts, vs) <- genDeclare pushScope var ty expr
+      pushGraph v EmittedStmt { emitStmts = stmts
+                              , emitBound = vs
+                              , emitBinds = binds
+                              , emitDeps  = deps }
+      pure vs
+
+-- | Generate the appropriate code for the provided yield.
+genYield :: (IsVar a, MonadState (EmitState a) m)
+          => EmitYield a -> [LuaExpr]
+          -> m (Seq LuaStmt, [LuaVar])
+genYield YieldReturn es = pure (pure (LuaReturn es), [])
+genYield YieldDiscard es = pure (foldMap asStmt es, [])
+genYield (YieldStore vs) es = pure (pure (LuaAssign vs es), vs)
+genYield (YieldDeclare v ty) es = genDeclare pushScope v ty es
+
+-- | Emit a declaration for a variable and a collection of expressions
+--
+-- This returns a 'LuaLocal' statement binding such expressions and the
+-- variables which were bound. We do not emit bindings for expressions
+-- which are just variables, returning variable directly.
+genDeclare :: Monad m
+            => (a -> m T.Text) -> a -> Type a -> [LuaExpr]
+            -> m (Seq LuaStmt, [LuaVar])
+genDeclare escape v ty es =
+  case traverse getVar es of
+    -- If all expressions are variables, then just return them
+    Just vs -> pure (mempty, vs)
+    Nothing -> do
+      v' <- escape v
+      pure $ case ty of
+        ValuesTy ts -> let (rs, lhs, rhs) = tupleVars v' 1 ts es
+                       in (pure (LuaLocal lhs rhs), rs)
+        _ -> let var = LuaName v'
+             in (pure (LuaLocal [var] es), [var])
+
+  where
+    -- | Get the variable from an expression
+    getVar (LuaRef v@LuaName{}) = Just v
+    getVar _ = Nothing
+
+    -- | Generate a set of bindings for a tuple variable
+    tupleVars :: T.Text -> Int -> [Type a] -> [LuaExpr]
+            -> ([LuaVar], [LuaVar], [LuaExpr])
+    tupleVars _ _ [] es = ([], [], es)
+    tupleVars v n (_:ts) [] =
+      let (rs, lhs, rhs) = tupleVars v (n + 1) ts es
+          var = LuaName (v <> T.pack ('_':show n))
+      in ( var : rs, var : lhs, rhs)
+    tupleVars v n (_:ts) (LuaRef var@LuaName{}:es) =
+      let (rs, lhs, rhs) = tupleVars v (n + 1) ts es
+      in ( var : rs, lhs, rhs)
+    tupleVars v n (_:ts) (e:es) =
+      let (rs, lhs, rhs) = tupleVars v (n + 1) ts es
+          var = LuaName (v <> T.pack ('_':show n))
+      in (var : rs, var : lhs, e   : rhs)
+
+-- | Generate the variables needed for this binding
+--
+-- This is effectively a simplified version of 'genDeclare' when you do
+-- not know the RHS.
+genVars :: Monad m
+            => (a -> m T.Text) -> a -> Type a
+            -> m [LuaVar]
+genVars es v (ValuesTy vs) = do
+  v' <- es v
+  let go _ [] = []
+      go n (_:ts) = LuaName (v' <> T.pack ('_':show n)) : go (n + 1) ts
+  pure (go (1 :: Int) vs)
+genVars es v _ = pure . LuaName <$> es v
+
+-- | Convert a literal into a Lua expression
+emitLit :: Literal -> LuaExpr
+emitLit (Int x)   = LuaInteger (fromIntegral x)
+emitLit (Float x) = LuaNumber x
+emitLit (Str str) = LuaString str
+emitLit LitTrue   = LuaTrue
+emitLit LitFalse  = LuaFalse
+emitLit Unit      = LuaRef (LuaName "__builtin_unit") -- Evil, but it works!
+emitLit RecNil    = LuaTable []
+
+emitStmt :: forall a m. (Occurs a, MonadState TopEmitState m)
+         => [Stmt a] -> m (Seq LuaStmt)
+emitStmt [] = pure mempty
+emitStmt (Foreign n t s:xs) = do
+  n' <- pushTopScope n
+  modify (\s -> s { topArity = extendForeign (topArity s) (n, t)
+                  , topVars = VarMap.insert (toVar n) [LuaName n'] (topVars s) })
+
+  let stmts = if arity t > 1
+              then
+                let ags = map LuaName $ take (arity t) alpha
+                    mkF (a:ag) bd = LuaFunction [a] [LuaReturn [mkF ag bd]]
+                    mkF [] bd = bd
+                in LuaLocal [LuaName (T.cons '_' n')] [LuaBitE s]
+                <| LuaLocal [LuaName n']
+                     [mkF ags
+                      (LuaCall (LuaRef (LuaName (T.cons '_' n')))
+                       (map LuaRef ags))]
+                <| mempty
+              else LuaLocal [LuaName n'] [LuaBitE s] <| mempty
+
+  (stmts<>) <$> emitStmt xs
+
+  where alpha :: [T.Text]
+        alpha = map T.pack ([1..] >>= flip replicateM ['a'..'z'])
+
+emitStmt (Type _ cs:xs) = do
+  stmts <- foldr (<|) mempty <$> traverse emitConstructor cs
+  modify (\s -> s { topArity = extendPureCtors (topArity s) cs })
+  (stmts<>) <$> emitStmt xs
+
+  where
+    emitConstructor (var, ty) = do
+      var' <- pushTopScope var
+      modify (\s -> s { topVars = VarMap.insert (toVar var) [LuaName var'] (topVars s) })
+
+      pure $
+        if arity ty == 0
+        then LuaLocal [LuaName var'] [LuaTable [(LuaString "__tag", LuaString var')]]
+        else LuaLocal [LuaName var'] [LuaFunction [LuaName "x"]
+                                       [LuaReturn [LuaTable [ (LuaString "__tag", LuaString var')
+                                                            , (LuaInteger 1, LuaRef (LuaName "x"))]]]]
+
+emitStmt (StmtLet (One (v, ty, e)):xs) = do
+  TopEmitState { topArity = ari, topEscape = esc, topVars = vars } <- get
+  let yield = if usedWhen v == Dead then YieldDiscard else YieldDeclare v ty
+      (stmts, binds) = emitTerm (EmitScope ari) esc
+                      (VarMap.mapWithKey (\v x -> EmittedUpvalue x [fromVar v] mempty) vars)
+                      yield e
+
+  modify (\s -> s { topArity = extendPureLets (topArity s) [(v, ty, e)]
+                  , topVars  = VarMap.insert (toVar v) binds (topVars s) })
+  (stmts<>) <$> emitStmt xs
+
+emitStmt (StmtLet (Many vs):xs) = do
+  TopEmitState { topArity = ari, topEscape = esc, topVars = vars } <- get
+
+  binds <- traverse (\(v, ty, _) -> genVars pushTopScope v ty) vs
+  modify (\s -> s { topArity = extendPureLets (topArity s) vs
+                  , topVars = foldr (\(v, b) -> VarMap.insert (toVar . fst3 $ v) b) (topVars s) (zip vs binds) })
+
+  let graph :: EmittedGraph a = VarMap.mapWithKey (\v x -> EmittedUpvalue x [fromVar v] mempty) vars
+      stmt = foldMap (\((_, _, e), v') -> fst $ emitTerm (EmitScope ari) esc graph (YieldStore v') e) (zip vs binds)
+  ((LuaLocal (mconcat binds) [] <| stmt) <>) <$> emitStmt xs
+
+-- | Push a new node into the emitting graph
+pushGraph :: (IsVar b, MonadState (EmitState a) m) => b -> EmittedNode a -> m ()
+pushGraph var node = modify (\s -> s { emitGraph = VarMap.insert (toVar var) node (emitGraph s) })
+
+-- | Push a variable into the current scope
+pushScope :: (IsVar a, MonadState (EmitState a) m) => a -> m T.Text
+pushScope v = state (\s -> let (v', s') = pushVar v (emitEscape s)
+                           in (v', s { emitEscape = s' }))
+
+-- | Push a variable into the current scope
+pushTopScope :: (IsVar a, MonadState TopEmitState m) => a -> m T.Text
+pushTopScope v = state (\s -> let (v', s') = pushVar v (topEscape s)
+                              in (v', s { topEscape = s' }))
+
+-- | Push a variable into the current scope
+pushScope' :: (IsVar a, MonadState (NodeEmitState a) m) => a -> m T.Text
+pushScope' v = state (\s -> let e = nodeState s
+                                (v', s') = pushVar v (emitEscape e)
+                            in (v', s { nodeState = e { emitEscape = s' } }))
+
+-- | Convert an expression into a set of Lua statements
+asStmt :: LuaExpr -> Seq LuaStmt
+asStmt (LuaTable fs) = foldr ((<>) . asStmt . snd) mempty fs
+asStmt (LuaBinOp a _ b) = asStmt a <> asStmt b
+asStmt (LuaCall f e) = pure (LuaCallS f e)
+asStmt _ = mempty
 
 patternBindings :: Occurs a => Pattern a -> [LuaExpr] -> [(a, [LuaExpr])]
 patternBindings (PatLit _) _     = []
@@ -453,30 +751,32 @@ patternBindings (Destr _ p) [vr] = patternBindings p [LuaRef (LuaIndex vr (LuaIn
 patternBindings (PatExtend p rs) [vr] = patternBindings p [vr] ++ concatMap (index vr) rs where
   index vr (var', pat) = patternBindings pat [LuaRef (LuaIndex vr (LuaString var'))]
 patternBindings (PatValues ps) vr = mconcat (zipWith (\p v -> patternBindings p [v]) ps vr)
-patternBindings _ _ = undefined
+patternBindings _ _ = error "Mismatch between pattern and expression arity"
 
-emitArm ::  (MonadState (EmitState v1) m, Occurs v)
-        => [LuaExpr]
-        -> ([LuaExpr] -> State (EmitState v) [LuaStmt])
-        -> AnnArm () v
-        -> m (LuaExpr, [LuaStmt])
-emitArm test next Arm { _armPtrn = p, _armBody = c } = do
-  esc <- use eEscape
-  pure ( patternTest esc p test
-       , let (once, multi) = partition ((==Once) . usedWhen . fst) (patternBindings p test)
-             (s', multi') = foldl (\(s, vs) (v, e) ->
-                                      let (v', s') = pushVar v s
-                                      in (s', (v', e): vs))
-                            (esc, []) multi
-         in (case multi' of
-                [] -> []
-                _ -> map (uncurry (mkBind LuaLocal)) multi')
-            ++ evalState (runContT (emitTerm c) next) (EmitState (withMatch once) s') )
+patternTest :: forall a. IsVar a => EscapeScope -> Pattern a -> [LuaExpr] ->  LuaExpr
+patternTest _ (Capture _ _) _       = LuaTrue
+patternTest _ (PatLit RecNil) _     = LuaTrue
+patternTest _ (PatLit l)  [vr]      = LuaBinOp (emitLit l) "==" vr
+patternTest s (PatExtend p rs) [vr] = foldAnd (patternTest s p [vr] : map test rs) where
+  test (var', pat) = patternTest s pat [LuaRef (LuaIndex vr (LuaString var'))]
+patternTest s (Constr con) [vr]    = foldAnd [tag s con vr]
+patternTest s (Destr con p) [vr]   = foldAnd [tag s con vr, patternTest s p [LuaRef (LuaIndex vr (LuaInteger 1))]]
+patternTest s (PatValues ps) vr   = foldAnd (zipWith (\p v -> patternTest s p [v]) ps vr)
+patternTest _ _ _ = undefined
 
-  where withMatch = map (\(a, b) -> VarEntry a b True)
+foldAnd :: [LuaExpr] -> LuaExpr
+foldAnd = foldl1 k where
+  k l r
+    | r == LuaTrue = l
+    | l == LuaTrue = r
+    | r == LuaFalse || l == LuaFalse = LuaFalse
+    | otherwise = LuaBinOp l "and" r
+
+tag :: IsVar a => EscapeScope -> a -> LuaExpr -> LuaExpr
+tag scp con vr = LuaBinOp (LuaRef (LuaIndex vr (LuaString "__tag"))) "==" (LuaString (getVar con scp))
 
 -- | A mapping from Amulet binary operators to their Lua equivalent.
-ops :: VarMap.Map Text
+ops :: VarMap.Map T.Text
 ops = VarMap.fromList
   [ (vOpAdd, "+"),  (vOpAddF, "+")
   , (vOpSub, "-"),  (vOpSubF, "-")
@@ -495,7 +795,7 @@ ops = VarMap.fromList
   ]
 
 -- | Remap an Amulet binary op to the equivalent Lua operator
-remapOp :: IsVar a => a -> Text
+remapOp :: IsVar a => a -> T.Text
 remapOp v | v'@(CoVar _ n _) <- toVar v = fromMaybe n (VarMap.lookup v' ops)
 
 -- | The default 'EscapeScope' for the backend

--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -707,11 +707,11 @@ emitStmt (StmtLet (One (v, ty, e)):xs) = do
   (stmts<>) <$> emitStmt xs
 
 emitStmt (StmtLet (Many vs):xs) = do
-  TopEmitState { topArity = ari, topEscape = esc, topVars = vars } <- get
-
   binds <- traverse (\(v, ty, _) -> genVars pushTopScope v ty) vs
   modify (\s -> s { topArity = extendPureLets (topArity s) vs
                   , topVars = foldr (\(v, b) -> VarMap.insert (toVar . fst3 $ v) b) (topVars s) (zip vs binds) })
+
+  TopEmitState { topArity = ari, topEscape = esc, topVars = vars } <- get
 
   let graph :: EmittedGraph a = VarMap.mapWithKey (\v x -> EmittedUpvalue x [fromVar v] mempty) vars
       (stmt, esc') = foldl' (\(s, esc') ((_, _, e), v') ->

--- a/src/Text/Dot.hs
+++ b/src/Text/Dot.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Text.Dot
+  ( Graph(..)
+  , GraphKind(..)
+  , GraphElement(..)
+  , ElemStyle(..)
+  , ElemInfo(..)
+  , defaultInfo
+  , drawGraph
+  , displayGraph
+  ) where
+
+import qualified Data.Text.Lazy.Builder.Int as B
+import qualified Data.Text.Lazy.Builder as B
+import qualified Data.Text.Lazy as L
+import qualified Data.Text as T
+import Data.Char
+
+import Text.Pretty
+
+data Graph a = Graph GraphKind [GraphElement a]
+
+data GraphKind = DirectedGraph | UndirectedGraph
+
+data ElemStyle = Solid | Dashed | Dotted
+  deriving (Show, Eq, Ord)
+
+data ElemInfo =
+  ElemInfo
+  { label :: Maybe T.Text
+  , style :: Maybe ElemStyle
+  }
+  deriving (Show)
+
+defaultInfo :: ElemInfo
+defaultInfo = ElemInfo Nothing Nothing
+
+data GraphElement a
+  = Node ElemInfo a
+  | Edge ElemInfo a a
+
+  | Subgraph [GraphElement a]
+
+drawGraph :: (a -> Doc b) -> Graph a -> Doc b
+drawGraph disp (Graph kind nodes) = name <+> "{" <#> vsep (map (indent 2 . elem) nodes) <#> "}"
+  where
+    name, sep :: Doc b
+    (name, sep) = case kind of
+             DirectedGraph -> ("digraph", "->")
+             UndirectedGraph -> ("graph", "--")
+
+    elem (Node info a) = disp a <> elemInfo info <> ";"
+    elem (Edge info a b) = disp a <+> sep <+> disp b <> elemInfo info <> ";"
+    elem (Subgraph nodes) = "subgraph {" <#> vsep (map (indent 2 . elem) nodes) <#> "}"
+
+    elemInfo info = case elemAttributes info of
+                      [] -> empty
+                      atr -> empty <+> "[" <+> hsep (punctuate comma atr) <+> "]"
+
+    elemAttributes (ElemInfo label style)
+      = maybe id ((:) . (\label -> "label=\"" <> text (escapeStr label) <> "\"")) label
+      . maybe id ((:) . (\style -> "style=" <> text (showStyle style))) style
+      $ []
+
+    escapeStr = L.toStrict . B.toLazyText . T.foldr (\x t -> escape x <> t) mempty
+    escape '\n' = "\\n"
+    escape '"' = "\\\""
+    escape '\t' = "\\t"
+    escape x | x < ' ' || x > '~' = "\\" <> B.decimal (ord x)
+             | otherwise = B.singleton x
+
+    showStyle Solid = "solid"
+    showStyle Dashed = "dashed"
+    showStyle Dotted = "dotted"
+
+displayGraph :: (a -> Doc b) -> Graph a -> T.Text
+displayGraph disp = display . renderPretty 0.4 100 . drawGraph disp

--- a/tests/lua/and.lua
+++ b/tests/lua/and.lua
@@ -18,18 +18,11 @@ do
     }
   end
   local bottom = nil
-  local cy = (function ()
-    local cw = bottom
-    if cw(1) then
-      local cu = __builtin_Lazy(function (cq)
-        return cw(2)
-      end)
-      local cm = __builtin_force
-      local dt = cm(cu)
-      local cv = bottom
-      return cv(dt)
-    else
-      return bottom(false)
-    end
-  end)()
+  if bottom(1) then
+    bottom(__builtin_force(__builtin_Lazy(function (cq)
+      return bottom(2)
+    end)))
+  else
+    bottom(false)
+  end
 end

--- a/tests/lua/arithmetic.lua
+++ b/tests/lua/arithmetic.lua
@@ -3,10 +3,5 @@ do
     __tag = "__builtin_unit"
   }
   local bottom = nil
-  local ce = (function ()
-    local cc = bottom
-    local cd = cc(1) + cc(2)
-    local cb = bottom
-    return cb(cd)
-  end)()
+  bottom(bottom(1) + bottom(2))
 end

--- a/tests/lua/begin_wrapper.lua
+++ b/tests/lua/begin_wrapper.lua
@@ -3,5 +3,5 @@ do
     __tag = "__builtin_unit"
   }
   local print = print
-  local main = print(false)
+  print(false)
 end

--- a/tests/lua/cse.lua
+++ b/tests/lua/cse.lua
@@ -9,10 +9,7 @@ do
       [1] = x
     }
   end
-  local ch = (function ()
-    local x = Foo(1)
-    local cd = print
-    cd(x)
-    return cd(x)
-  end)()
+  local x = Foo(1)
+  print(x)
+  print(x)
 end

--- a/tests/lua/escape.lua
+++ b/tests/lua/escape.lua
@@ -3,7 +3,7 @@ do
     __tag = "__builtin_unit"
   }
   local bottom = nil
-  local s = bottom({
+  bottom({
     quote = "\"",
     line = "\n",
     tab = "\t",

--- a/tests/lua/function_order.lua
+++ b/tests/lua/function_order.lua
@@ -3,12 +3,8 @@ do
     __tag = "__builtin_unit"
   }
   local bottom = nil
-  local db = (function ()
-    local cy = bottom
-    local a = cy(1)
-    local b = cy(2)
-    local c = cy(3)
-    local da = bottom
-    return da(b)(c)(a)
-  end)()
+  local a = bottom(1)
+  local b = bottom(2)
+  local c = bottom(3)
+  bottom(b)(c)(a)
 end

--- a/tests/lua/if.lua
+++ b/tests/lua/if.lua
@@ -3,16 +3,9 @@ do
     __tag = "__builtin_unit"
   }
   local bottom = nil
-  local bd = (function ()
-    local bb = bottom
-    if bb(1) then
-      local bk = bb(2)
-      local ba = bottom
-      return ba(bk)
-    else
-      local bl = bb(3)
-      local ba = bottom
-      return ba(bl)
-    end
-  end)()
+  if bottom(1) then
+    bottom(bottom(2))
+  else
+    bottom(bottom(3))
+  end
 end

--- a/tests/lua/let_pattern.lua
+++ b/tests/lua/let_pattern.lua
@@ -13,7 +13,7 @@ do
   local d = dj._1
   local e = dj._2
   local bottom = nil
-  local ec = bottom({
+  bottom({
     a = 3,
     b = 5,
     c = 6,

--- a/tests/lua/let_pattern_partial.lua
+++ b/tests/lua/let_pattern_partial.lua
@@ -2,5 +2,5 @@ do
   local __builtin_unit = {
     __tag = "__builtin_unit"
   }
-  local e = error("Pattern matching failure in let expression at let_pattern_partial.ml[1:5 ..1:9]")
+  error("Pattern matching failure in let expression at let_pattern_partial.ml[1:5 ..1:9]")
 end

--- a/tests/lua/match_consumed.lua
+++ b/tests/lua/match_consumed.lua
@@ -12,18 +12,10 @@ do
     }
   end
   local bottom = nil
-  local dq = (function ()
-    local dm = bottom
-    local a = dm(1)
-    local _do = bottom
-    if _do.__tag == "None" then
-      local fz = dm(a)
-      local dl = bottom
-      return dl(fz)
-    elseif _do.__tag == "Some" then
-      local ga = dm(a + _do[1] * 2)
-      local dl = bottom
-      return dl(ga)
-    end
-  end)()
+  local a = bottom(1)
+  if bottom.__tag == "None" then
+    bottom(bottom(a))
+  elseif bottom.__tag == "Some" then
+    bottom(bottom(a + bottom[1] * 2))
+  end
 end

--- a/tests/lua/match_multi.lua
+++ b/tests/lua/match_multi.lua
@@ -3,10 +3,6 @@ do
     __tag = "__builtin_unit"
   }
   local bottom = nil
-  local bm = (function ()
-    local bc = bottom(__builtin_unit)
-    local bl = bc.a + bc.b
-    local bi = bottom
-    return bi(bl)
-  end)()
+  local bc = bottom(__builtin_unit)
+  bottom(bc.a + bc.b)
 end

--- a/tests/lua/newtype.lua
+++ b/tests/lua/newtype.lua
@@ -27,11 +27,8 @@ do
     }
   end
   local bottom = nil
-  local fb = (function ()
-    local fa = bottom
-    fa(Foo)
-    fa(Bar)
-    fa(It)
-    return fa(Mk)
-  end)()
+  bottom(Foo)
+  bottom(Bar)
+  bottom(It)
+  bottom(Mk)
 end

--- a/tests/lua/pattern_multiple_consume.lua
+++ b/tests/lua/pattern_multiple_consume.lua
@@ -1,0 +1,15 @@
+do
+  local __builtin_unit = {
+    __tag = "__builtin_unit"
+  }
+  local main
+  main = function (an)
+    local x = an.x
+    return x + main({
+      x = x
+    })
+  end
+  main({
+    x = 1
+  })
+end

--- a/tests/lua/pattern_multiple_consume.ml
+++ b/tests/lua/pattern_multiple_consume.ml
@@ -1,0 +1,2 @@
+let main { x } = x + main { x }
+let _ = main { x = 1 }

--- a/tests/lua/record_extend.lua
+++ b/tests/lua/record_extend.lua
@@ -3,16 +3,12 @@ do
     __tag = "__builtin_unit"
   }
   local bottom = nil
-  local au = (function ()
-    local __o, __n = bottom, {
-      
-    }
-    for k, v in pairs(__o) do
-      __n[k] = v
-    end
-    __n.x = 1
-    local at = __n
-    local aq = bottom
-    return aq(at)
-  end)()
+  local at = {
+    
+  }
+  for k, v in pairs(bottom) do
+    at[k] = v
+  end
+  at.x = 1
+  bottom(at)
 end

--- a/tests/lua/reduce_single_constructor.lua
+++ b/tests/lua/reduce_single_constructor.lua
@@ -15,10 +15,10 @@ do
   end
   local go0 = nil
   go0(__builtin_unit)
-  local main = Mono0(2)
+  local main0 = Mono0(2)
   local bottom = nil
   bottom({
     _1 = main,
-    _2 = main
+    _2 = main0
   })
 end

--- a/tests/lua/reduce_single_constructor.lua
+++ b/tests/lua/reduce_single_constructor.lua
@@ -14,13 +14,11 @@ do
     }
   end
   local go0 = nil
-  local main0 = (function ()
-    go0(__builtin_unit)
-    return Mono0(2)
-  end)()
+  go0(__builtin_unit)
+  local main = Mono0(2)
   local bottom = nil
-  local cq = bottom({
+  bottom({
     _1 = main,
-    _2 = main0
+    _2 = main
   })
 end

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -24,5 +24,5 @@ do
     }
   }
   local bottom = nil
-  local br = bottom(main)
+  bottom(main)
 end

--- a/tests/lua/stream.lua
+++ b/tests/lua/stream.lua
@@ -26,19 +26,17 @@ do
       [1] = x
     }
   end
-  local main = (function ()
-    local go
-    go = function (st)
-      if st > 5 then
-        return print("]")
-      else
-        io_write("'" .. to_string(st) .. "', ")
-        return go(st + 1)
-      end
+  local go
+  go = function (st)
+    if st > 5 then
+      return print("]")
+    else
+      io_write("'" .. to_string(st) .. "', ")
+      return go(st + 1)
     end
-    io_write("[")
-    return go(1)
-  end)()
+  end
+  io_write("[")
+  local main = go(1)
   local bottom = nil
-  local og = bottom(main)
+  bottom(main)
 end

--- a/tests/lua/tuple_literal.lua
+++ b/tests/lua/tuple_literal.lua
@@ -3,19 +3,12 @@ do
     __tag = "__builtin_unit"
   }
   local bottom = nil
-  local ci = (function ()
-    local cg = bottom
-    local a = cg(1)
-    local b = cg(2)
-    local c = cg(3)
-    local ch = {
-      _1 = b,
-      _2 = {
-        _1 = c,
-        _2 = a
-      }
+  local a = bottom(1)
+  bottom({
+    _1 = bottom(2),
+    _2 = {
+      _1 = bottom(3),
+      _2 = a
     }
-    local ce = bottom
-    return ce(ch)
-  end)()
+  })
 end


### PR DESCRIPTION
The previous version of the codegen operated on the concept of an expression "stack". We'd push new variables onto the stack, and pop them when they were consumed. If a variable did note match up, we'd convert the entire stack into local variables, to ensure that the order of side effects was preserved.

While this worked well for unprocessed inputs, the optimiser would often reorder terms in such a way that the codegen would flush bindings more often than needed, meaning we'd generate rather silly Lua.

This rewritten codegen handles execution order via a graph instead. We walk down the spine of let expressions, and gather expressions and their dependencies (free variables and the preceding impure expression).

Expressions which are only used once can be embedded inline as long as doing so does not introduce a conflict (determined by a loop in the dependency graph). Otherwise they are emitted as individual statements and emitted to the graph.

When a block has been fully generated, we perform a topological sort of the dependency graph, concatenating all statements together.

The other noticeable difference compared to the previous generator is the introduction of "yield contexts". These simply determine how a given node is consumed - it could be discarded, returned, declare a new variable or bound to an existing one. This allows us to perform more fine-grained code generation is several cases (such as when emitting
matches or record extensions).