### PR TITLE
Rework the Lua pretty printer a little

### DIFF
--- a/tests/lua/and.lua
+++ b/tests/lua/and.lua
@@ -1,8 +1,6 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
-  local function __builtin_force (x)
+  local __builtin_unit = { __tag = "__builtin_unit" }
+  local function __builtin_force(x)
     if x[2] then
       return x[1]
     else
@@ -10,18 +8,10 @@ do
       return x[1]
     end
   end
-  local function __builtin_Lazy (x)
-    return {
-      [1] = x,
-      [2] = false,
-      __tag = "lazy"
-    }
-  end
+  local function __builtin_Lazy(x) return { x, false, __tag = "lazy" } end
   local bottom = nil
   if bottom(1) then
-    bottom(__builtin_force(__builtin_Lazy(function (cq)
-      return bottom(2)
-    end)))
+    bottom(__builtin_force(__builtin_Lazy(function(cq) return bottom(2) end)))
   else
     bottom(false)
   end

--- a/tests/lua/arithmetic.lua
+++ b/tests/lua/arithmetic.lua
@@ -1,7 +1,5 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
   bottom(bottom(1) + bottom(2))
 end

--- a/tests/lua/begin_wrapper.lua
+++ b/tests/lua/begin_wrapper.lua
@@ -1,7 +1,5 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local print = print
   print(false)
 end

--- a/tests/lua/cse.lua
+++ b/tests/lua/cse.lua
@@ -1,14 +1,7 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local print = print
-  local function Foo (x)
-    return {
-      __tag = "Foo",
-      [1] = x
-    }
-  end
+  local function Foo(x) return { __tag = "Foo", x } end
   local x = Foo(1)
   print(x)
   print(x)

--- a/tests/lua/escape.lua
+++ b/tests/lua/escape.lua
@@ -1,12 +1,5 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
-  bottom({
-    quote = "\"",
-    line = "\n",
-    tab = "\t",
-    hex = "\17"
-  })
+  bottom({ quote = "\"", line = "\n", tab = "\t", hex = "\17" })
 end

--- a/tests/lua/function_order.lua
+++ b/tests/lua/function_order.lua
@@ -1,7 +1,5 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
   local a = bottom(1)
   local b = bottom(2)

--- a/tests/lua/if.lua
+++ b/tests/lua/if.lua
@@ -1,7 +1,5 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
   if bottom(1) then
     bottom(bottom(2))

--- a/tests/lua/let_pattern.lua
+++ b/tests/lua/let_pattern.lua
@@ -1,23 +1,8 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
-  local dj = {
-    _1 = function (x)
-      return x
-    end,
-    _2 = function (x)
-      return x
-    end
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
+  local dj = { _1 = function(x) return x end, _2 = function(x) return x end }
   local d = dj._1
   local e = dj._2
   local bottom = nil
-  bottom({
-    a = 3,
-    b = 5,
-    c = 6,
-    d = d,
-    e = e
-  })
+  bottom({ a = 3, b = 5, c = 6, d = d, e = e })
 end

--- a/tests/lua/let_pattern_partial.lua
+++ b/tests/lua/let_pattern_partial.lua
@@ -1,6 +1,4 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   error("Pattern matching failure in let expression at let_pattern_partial.ml[1:5 ..1:9]")
 end

--- a/tests/lua/match_consumed.lua
+++ b/tests/lua/match_consumed.lua
@@ -1,20 +1,12 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
-  local None = {
-    __tag = "None"
-  }
-  local function Some (x)
-    return {
-      __tag = "Some",
-      [1] = x
-    }
-  end
+  local __builtin_unit = { __tag = "__builtin_unit" }
+  local None = { __tag = "None" }
+  local function Some(x) return { __tag = "Some", x } end
   local bottom = nil
   local a = bottom(1)
   if bottom.__tag == "None" then
     bottom(bottom(a))
+
   elseif bottom.__tag == "Some" then
     bottom(bottom(a + bottom[1] * 2))
   end

--- a/tests/lua/match_multi.lua
+++ b/tests/lua/match_multi.lua
@@ -1,7 +1,5 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
   local bc = bottom(__builtin_unit)
   bottom(bc.a + bc.b)

--- a/tests/lua/newtype.lua
+++ b/tests/lua/newtype.lua
@@ -1,31 +1,9 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
-  local function Foo (x)
-    return {
-      __tag = "Foo",
-      [1] = x
-    }
-  end
-  local function Bar (x)
-    return {
-      __tag = "Bar",
-      [1] = x
-    }
-  end
-  local function It (x)
-    return {
-      __tag = "It",
-      [1] = x
-    }
-  end
-  local function Mk (x)
-    return {
-      __tag = "Mk",
-      [1] = x
-    }
-  end
+  local __builtin_unit = { __tag = "__builtin_unit" }
+  local function Foo(x) return { __tag = "Foo", x } end
+  local function Bar(x) return { __tag = "Bar", x } end
+  local function It(x) return { __tag = "It", x } end
+  local function Mk(x) return { __tag = "Mk", x } end
   local bottom = nil
   bottom(Foo)
   bottom(Bar)

--- a/tests/lua/pattern_multiple_consume.lua
+++ b/tests/lua/pattern_multiple_consume.lua
@@ -1,15 +1,9 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local main
-  main = function (an)
+  main = function(an)
     local x = an.x
-    return x + main({
-      x = x
-    })
+    return x + main({ x = x })
   end
-  main({
-    x = 1
-  })
+  main({ x = 1 })
 end

--- a/tests/lua/record_extend.lua
+++ b/tests/lua/record_extend.lua
@@ -1,11 +1,7 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
-  local at = {
-    
-  }
+  local at = {}
   for k, v in pairs(bottom) do
     at[k] = v
   end

--- a/tests/lua/reduce_single_constructor.lua
+++ b/tests/lua/reduce_single_constructor.lua
@@ -1,24 +1,12 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
-  local Mono = {
-    __tag = "Mono"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
+  local Mono = { __tag = "Mono" }
   local go = nil
   local main = go(__builtin_unit)
-  local function Mono0 (x)
-    return {
-      __tag = "Mono0",
-      [1] = x
-    }
-  end
+  local function Mono0(x) return { __tag = "Mono0", x } end
   local go0 = nil
   go0(__builtin_unit)
   local main0 = Mono0(2)
   local bottom = nil
-  bottom({
-    _1 = main,
-    _2 = main0
-  })
+  bottom({ _1 = main, _2 = main0 })
 end

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -1,26 +1,11 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
-  local function _plus0 (bv)
-    return function (bw)
-      return bv + bw
-    end
-  end
+  local __builtin_unit = { __tag = "__builtin_unit" }
+  local function _plus0(bv) return function(bw) return bv + bw end end
   local main = {
     _1 = _plus0,
     _2 = {
-      _1 = function (bz)
-        return 2 * bz
-      end,
-      _2 = {
-        _1 = function (d)
-          return d / 2
-        end,
-        _2 = function (e)
-          return e.foo
-        end
-      }
+      _1 = function(bz) return 2 * bz end,
+      _2 = { _1 = function(d) return d / 2 end, _2 = function(e) return e.foo end }
     }
   }
   local bottom = nil

--- a/tests/lua/stream.lua
+++ b/tests/lua/stream.lua
@@ -1,33 +1,14 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local io_write = io.write
   local print = print
   local to_string = tostring
-  local function Skip (x)
-    return {
-      __tag = "Skip",
-      [1] = x
-    }
-  end
-  local function Yield (x)
-    return {
-      __tag = "Yield",
-      [1] = x
-    }
-  end
-  local Done = {
-    __tag = "Done"
-  }
-  local function Stream (x)
-    return {
-      __tag = "Stream",
-      [1] = x
-    }
-  end
+  local function Skip(x) return { __tag = "Skip", x } end
+  local function Yield(x) return { __tag = "Yield", x } end
+  local Done = { __tag = "Done" }
+  local function Stream(x) return { __tag = "Stream", x } end
   local go
-  go = function (st)
+  go = function(st)
     if st > 5 then
       return print("]")
     else

--- a/tests/lua/tuple_literal.lua
+++ b/tests/lua/tuple_literal.lua
@@ -1,14 +1,6 @@
 do
-  local __builtin_unit = {
-    __tag = "__builtin_unit"
-  }
+  local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
   local a = bottom(1)
-  bottom({
-    _1 = bottom(2),
-    _2 = {
-      _1 = bottom(3),
-      _2 = a
-    }
-  })
+  bottom({ _1 = bottom(2), _2 = { _1 = bottom(3), _2 = a } })
 end


### PR DESCRIPTION
 - Handle "array entries" within Lua tables, so we can pretty print `{ 1, 2, 3 }` correctly.
 - `group` some expressions, allowing them to be emitted on one line. We currently do this to simple functions (only a return) and tables.