### PR TITLE
Lua quasi-quoter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@
 
 src/Parser/Lexer.hs
 src/Parser.hs
-src/*.info
+src/Language/Lua/Parser/Lexer.hs
+src/Language/Lua/Parser/Parser.hs
+src/**/*.info
 
 !/tests/lua/*.lua
 

--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -119,6 +119,7 @@ library amulet
                      , hashable >= 1.2 && < 1.3
                      , containers >= 0.5 && < 0.6
                      , transformers >= 0.5 && < 0.6
+                     , template-haskell >= 2.13 && < 2.14
                      , annotated-wl-pprint >= 0.7 && < 0.8
                      , unordered-containers >= 0.2 && < 0.3
                      , pretty-show
@@ -202,7 +203,13 @@ library amulet
                      , Backend.Lua.Postprocess
                      , Backend.Escape
                      -- Lua
+                     , Language.Lua.Quote
                      , Language.Lua.Syntax
+                     , Language.Lua.Parser.Error
+                     , Language.Lua.Parser.Lexer
+                     , Language.Lua.Parser.Token
+                     , Language.Lua.Parser.Parser
+                     , Language.Lua.Parser.Wrapper
                      -- Infra
                      , Control.Monad.Infer
                      , Control.Monad.Namey

--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -199,9 +199,10 @@ library amulet
                      -- Backend
                      , Backend.Lua
                      , Backend.Lua.Emit
-                     , Backend.Lua.Syntax
                      , Backend.Lua.Postprocess
                      , Backend.Escape
+                     -- Lua
+                     , Language.Lua.Syntax
                      -- Infra
                      , Control.Monad.Infer
                      , Control.Monad.Namey

--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -17,7 +17,7 @@ import Control.Monad.Infer (Env, TypeError, firstName)
 import Control.Monad.Namey
 import Control.Monad.State
 
-import Backend.Lua.Syntax
+import Language.Lua.Syntax
 import Backend.Lua
 
 import Types.Infer (inferProgram, builtinsEnv)

--- a/compiler/Repl.hs
+++ b/compiler/Repl.hs
@@ -57,7 +57,7 @@ import Control.Lens
 
 import qualified Backend.Lua.Postprocess as B
 import qualified Backend.Lua.Emit as B
-import Backend.Lua.Syntax
+import Language.Lua.Syntax
 
 import Text.Pretty.Semantic
 import Text.Pretty.Note

--- a/default.nix
+++ b/default.nix
@@ -57,6 +57,7 @@ let
       , tasty-hunit
       , transformers
       , tasty-ant-xml
+      , template-haskell
       , annotated-wl-pprint
       , unordered-containers
       , tasty-hedgehog_0_2_0_0
@@ -74,7 +75,7 @@ let
 
         libraryHaskellDepends = [
           annotated-wl-pprint array base bytestring containers lens
-          mtl pretty-show syb text transformers hashable
+          mtl pretty-show syb text transformers template-haskell hashable
           unordered-containers
         ];
 

--- a/src/Backend/Lua.hs
+++ b/src/Backend/Lua.hs
@@ -12,8 +12,9 @@ import Control.Monad.State
 
 import Data.Foldable
 
+import Language.Lua.Syntax
+
 import Backend.Lua.Postprocess
-import Backend.Lua.Syntax
 import Backend.Lua.Emit
 
 import Core.Occurrence

--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -417,7 +417,7 @@ emitExpr var yield (AnnExtend fv tbl exs) = do
       in LuaLocal [old] [tbl] <| copy var old <| mempty
 
     copy var tbl =
-      LuaFor [k, v] [LuaCall (LuaRef pairs) [LuaRef tbl]]
+      LuaFor [LuaName k, LuaName v] [LuaCall (LuaRef pairs) [LuaRef tbl]]
          [LuaAssign [LuaIndex (LuaRef var) (LuaRef (LuaName k))] [LuaRef (LuaName v)]]
 
 runNES :: ( MonadReader (EmitScope a) m

--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -27,7 +27,7 @@ import Core.Types
 import Core.Core
 import Core.Var
 
-import Backend.Lua.Syntax
+import Language.Lua.Syntax
 import Backend.Escape
 
 -- | A magic variable used to represent the return value

--- a/src/Backend/Lua/Postprocess.hs
+++ b/src/Backend/Lua/Postprocess.hs
@@ -13,7 +13,7 @@ import qualified Data.Map as Map
 import qualified Data.VarMap as VarMap
 import qualified Data.VarSet as VarSet
 
-import Backend.Lua.Syntax
+import Language.Lua.Syntax
 import Backend.Lua.Emit
 import Backend.Escape
 import Core.Builtin

--- a/src/Backend/Lua/Postprocess.hs
+++ b/src/Backend/Lua/Postprocess.hs
@@ -43,7 +43,8 @@ addOperators stmt =
     opsStmt (LuaIfElse t) = foldMap (\(c, b) -> opsExpr c <> foldMap opsStmt b) t
     opsStmt LuaBreak = mempty
     opsStmt (LuaCallS f xs) = foldMap opsExpr (f:xs)
-    opsStmt LuaBit{} = mempty
+    opsStmt LuaBitS{} = mempty
+    opsStmt LuaQuoteS{} = mempty
 
     opsExpr :: LuaExpr -> VarSet.Set
     opsExpr LuaNil = mempty
@@ -54,6 +55,7 @@ addOperators stmt =
     opsExpr LuaInteger{} = mempty
     opsExpr LuaString{} = mempty
     opsExpr LuaBitE{} = mempty
+    opsExpr LuaQuoteE{} = mempty
 
     opsExpr (LuaCall f xs) = foldMap opsExpr (f:xs)
     opsExpr (LuaRef v) = opsVar v
@@ -64,6 +66,7 @@ addOperators stmt =
     opsVar :: LuaVar -> VarSet.Set
     opsVar (LuaName t) = foldMap VarSet.singleton (Map.lookup t opNames)
     opsVar (LuaIndex t k) = opsExpr t <> opsExpr k
+    opsVar LuaQuoteV{} = mempty
 
     opNames = Map.filter (`VarMap.member` ops) (fromEsc escapeScope)
                 `Map.union` Map.fromList [ ( "__builtin_Lazy", vLAZY ), ( "__builtin_force", vForce ) ]

--- a/src/Backend/Lua/Postprocess.hs
+++ b/src/Backend/Lua/Postprocess.hs
@@ -79,7 +79,11 @@ addOperators stmt =
 -- apply to binary operators.
 genOperator :: CoVar -> LuaStmt
 genOperator op | op == vLAZY =
-  [luaStmt|local __builtin_Lazy = function(x) return { x, false, __tag = "lazy" } end|]
+  [luaStmt|
+    local __builtin_Lazy = function(x)
+      return { x, false, __tag = "lazy" }
+    end
+  |]
 
 genOperator op | op == vForce =
   [luaStmt|
@@ -87,7 +91,12 @@ genOperator op | op == vForce =
      if x[2] then
        return x[1]
      else
-       x[1], x[2] = x[1](__builtin_unit), true
+       local thunk = x[1]
+       x[1] = function()
+         error("loop while forcing thunk")
+       end
+       x[1] = thunk(__builtin_unit)
+       x[2] = true
        return x[1]
      end
    end

--- a/src/Language/Lua/Parser/Error.hs
+++ b/src/Language/Lua/Parser/Error.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE OverloadedStrings, MultiParamTypeClasses #-}
+
+-- | Represents and handles errors within the parsing process
+module Language.Lua.Parser.Error
+  ( ParseError(..)
+  ) where
+
+import Data.Position
+import Data.Spanned
+import Data.Span
+import Data.Char
+
+import Text.Pretty.Semantic (Pretty(..), Style)
+import Text.Pretty.Note
+import Text.Pretty
+
+import Language.Lua.Parser.Token
+
+-- | An error in the parsing process
+--
+-- It's worth noting that not all errors are irrecoverable, though all
+-- suggest some form of incorrect code. One should use 'diagnosticKind'
+-- to determine how serious an error is.
+data ParseError
+  -- | Represents an error with an arbitrary message. This is used by
+  -- 'fail'
+  = Failure SourcePos String
+
+  -- | An unexpected character in the input text
+  | UnexpectedCharacter SourcePos Char
+  -- | The end of the file was unexpectedly reached
+  | UnexpectedEnd SourcePos
+  -- | A string was not correctly terminated (due to a new line or the
+  -- end of a file)
+  | UnclosedString SourcePos SourcePos
+  -- | A comment was not correctly terminated (due to the end of the
+  -- file).
+  | UnclosedComment SourcePos SourcePos
+
+  -- | An unexpected token appeared in the lexer stream
+  | UnexpectedToken Token [String]
+  deriving (Show)
+
+instance Pretty ParseError where
+  pretty (Failure _ s) = string s
+
+  pretty (UnexpectedCharacter _ c) | isPrint c = "Unexpected character '" <> string [c] <> "'"
+                                   | otherwise = "Unexpected character" <+> shown c
+  pretty (UnexpectedEnd _) = string "Unexpected end of input"
+  pretty (UnclosedString _ p) = "Unexpected end of input, expecting to close string started at" <+> prettyPos p
+  pretty (UnclosedComment _ p) = "Unexpected end of input, expecting to close comment started at" <+> prettyPos p
+
+  pretty (UnexpectedToken (Token s _ _) []) = "Unexpected" <+> string (show s)
+  pretty (UnexpectedToken (Token s _ _) [x]) = "Unexpected" <+> string (show s) <> ", expected" <+> string x
+  pretty (UnexpectedToken (Token s _ _) xs) = "Unexpected" <+> string (show s) <> ", expected one of" <+> hsep (punctuate comma (map string xs))
+
+instance Spanned ParseError where
+  annotation (Failure p _) = mkSpan1 p
+
+  annotation (UnexpectedCharacter p _) = mkSpan1 p
+  annotation (UnexpectedEnd p) = mkSpan1 p
+  annotation (UnclosedString p _) = mkSpan1 p
+  annotation (UnclosedComment p _) = mkSpan1 p
+
+  annotation (UnexpectedToken t _) = annotation t
+
+prettyPos :: SourcePos -> Doc a
+prettyPos p = shown (spLine p) <> colon <> shown (spCol p)
+
+instance Note ParseError Style where
+  diagnosticKind _ = ErrorMessage
+
+  formatNote f (UnclosedString p s)
+    = indent 2 "Unexpected end of input, expecting to close string"
+      <##> f [mkSpan1 s, mkSpan1 p]
+  formatNote f (UnclosedComment p s)
+    = indent 2 "Unexpected end of input, expecting to close comment"
+      <##> f [mkSpan1 s, mkSpan1 p]
+  formatNote f x
+    = indent 2 (Right <$> pretty x)
+      <##> f [annotation x]

--- a/src/Language/Lua/Parser/Lexer.x
+++ b/src/Language/Lua/Parser/Lexer.x
@@ -1,0 +1,219 @@
+{
+{-# OPTIONS_GHC -Wwarn -Wno-unused-imports -Wno-monomorphism-restriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Language.Lua.Parser.Lexer (lexerScan) where
+
+import qualified Data.Text.Lazy.Builder as B
+import qualified Data.Text.Lazy as L
+import qualified Data.Text.Read as R
+import qualified Data.Text as T
+
+import Data.Char (chr, digitToInt)
+import Data.Span
+import Data.Semigroup
+import Data.Position
+import Data.Spanned
+import Data.Span
+
+import Language.Lua.Parser.Error
+import Language.Lua.Parser.Token
+import Language.Lua.Parser.Wrapper
+}
+
+%encoding "latin1"
+
+$digit = [0-9]               -- Digits
+$hex   = [0-9A-Fa-f]         -- Hexadecimal digits
+$upper = [A-Z] -- Uppercase characters
+$lower = [a-z] -- Lowercase characters
+
+$identHead = [$upper $lower '_'] -- Valid starting identifier characters
+$identTail = [$identHead $digit] -- Valid remaining identifier characters
+
+tokens :-
+  <0> $white+    { trivialTok TcWhitespace }
+  <0> "--" .*    { trivialTok TcComment }
+
+  -- Keywords
+  <0> "and"      { constTok TcAnd }
+  <0> "break"    { constTok TcBreak }
+  <0> "do"       { constTok TcDo }
+  <0> "else"     { constTok TcElse }
+  <0> "elseif"   { constTok TcElseIf }
+  <0> "end"      { constTok TcEnd }
+  <0> "false"    { constTok TcFalse }
+  <0> "for"      { constTok TcFor }
+  <0> "function" { constTok TcFunction }
+  <0> "if"       { constTok TcIf }
+  <0> "in"       { constTok TcIn }
+  <0> "local"    { constTok TcLocal }
+  <0> "nil"      { constTok TcNil }
+  <0> "not"      { constTok TcNot }
+  <0> "or"       { constTok TcOr }
+  <0> "repeat"   { constTok TcRepeat }
+  <0> "return"   { constTok TcReturn }
+  <0> "then"     { constTok TcThen }
+  <0> "true"     { constTok TcTrue }
+  <0> "until"    { constTok TcUntil }
+  <0> "while"    { constTok TcWhile }
+
+  -- Symbols
+  <0> ":"        { constTok TcColon }
+  <0> ","        { constTok TcComma }
+  <0> "."        { constTok TcDot }
+  <0> "..."      { constTok TcDots }
+  <0> "="        { constTok TcEquals }
+  <0> ";"        { constTok TcSemicolon }
+
+  <0> "("        { constTok TcOParen }
+  <0> ")"        { constTok TcCParen }
+  <0> "{"        { constTok TcOBrace }
+  <0> "}"        { constTok TcCBrace }
+  <0> "["        { constTok TcOSquare }
+  <0> "]"        { constTok TcCSquare }
+
+  -- Operators
+  <0> "+"        { constTok TcAdd }
+  <0> "-"        { constTok TcSub }
+  <0> "*"        { constTok TcMul }
+  <0> "/"        { constTok TcDiv }
+  <0> "^"        { constTok TcPow }
+  <0> "%"        { constTok TcMod }
+
+  <0> "=="       { constTok TCEq }
+  <0> "~="       { constTok TCNe }
+  <0> "<"        { constTok TcLt }
+  <0> ">"        { constTok TcGt }
+  <0> "<="       { constTok TcLe }
+  <0> ">="       { constTok TcGe }
+
+  -- Numbers
+  <0> $digit+                          { onString $ TcInteger . parseNum 10 }
+  <0> 0 x $hex+                        { onString $ TcInteger . parseNum 16 . L.drop 2 }
+
+  <0> $digit+ \. $digit+               { onString $ TcFloat . parseDouble }
+  <0> $digit+ \. $digit+ [Ee] $digit+  { onString $ TcFloat . parseDouble }
+  <0> $digit+ \. $digit+ [Ee] [\+\-] $digit+ { onString $ TcFloat . parseDouble }
+
+  -- Identifiers
+  <0> $identHead $identTail*           { lexTok $ TcIdentifier }
+  <0> "%" $identHead $identTail*       { lexTok $ TcQuoteE . T.tail }
+  <0> "@" $identHead $identTail*       { lexTok $ TcQuoteS . T.tail }
+  <0> "$" $identHead $identTail*       { lexTok $ TcQuoteV . T.tail }
+
+  -- Strings
+  <0> \"                               { beginString '\"' }
+  <0> \'                               { beginString '\'' }
+
+  <string> \"                          { endString '\"' }
+  <string> \'                          { endString '\'' }
+
+  <string> \\ a                        { appendChar '\a' }
+  <string> \\ b                        { appendChar '\b' }
+  <string> \\ f                        { appendChar '\f' }
+  <string> \\ n                        { appendChar '\n' }
+  <string> \\ r                        { appendChar '\r' }
+  <string> \\ v                        { appendChar '\v' }
+  <string> \\ t                        { appendChar '\t' }
+
+  <string> \\ \\                       { appendChar '\\' }
+  <string> \\ \"                       { appendChar '\"' }
+  <string> \\ \'                       { appendChar '\'' }
+
+  <string> \\ x $hex+                  { onStringM $ appendChar . chr . parseNum 16 . L.drop 2 }
+
+  <string> [^\\\"\']+                  { onStringM append }
+
+{
+
+fToken :: SourcePos -> SourcePos -> TokenClass -> Token
+fToken s e t = Token t s e
+
+parseNum :: Num a => a -> L.Text -> a
+parseNum radix = L.foldl' (\accum digit -> accum * radix + fromIntegral (digitToInt digit)) 0
+
+parseDouble :: L.Text -> Double
+parseDouble t = case (R.double . L.toStrict) t of
+                  Right (x, t) | T.null t -> x
+                  _ -> error "Cannot parse float"
+
+appendChar :: Char -> Action Token
+appendChar c _ _ _ = do
+  s <- getState
+  setState $ s { stringBuffer = stringBuffer s <> B.singleton c }
+  lexerScan -- Don't emit a token, just continue
+
+append :: L.Text -> Action Token
+append c _ _ _ = do
+  s <- getState
+  setState $ s { stringBuffer = stringBuffer s <> B.fromLazyText c }
+  lexerScan -- Don't emit a token, just continue
+
+beginString, endString :: Char -> Action Token
+beginString c (LI p _ _ _) _ _ = do
+  mapState $ \s -> s { tokenStart = p, stringChar = c }
+  setStartCode string
+  lexerScan
+endString c _ _ ep = do
+  s <- getState
+  if stringChar s == c
+  then do
+    -- Characters match, terminate
+    setState $ s { stringBuffer = "" }
+    setStartCode 0
+    pure . fToken (tokenStart s) ep .  TcString . L.toStrict . B.toLazyText . stringBuffer $ s
+  else do
+    -- Don't emit a token, just continue
+    setState $ s { stringBuffer = stringBuffer s <> B.singleton c }
+    lexerScan
+
+trivialTok :: (T.Text -> TokenClass) -> Action Token
+trivialTok f (LI sp str _ _) len ep = do
+  s <- getState
+  if trivials s
+  then pure $! Token (f (L.toStrict (L.take len str))) sp ep
+  else lexerScan
+
+constTok :: TokenClass -> Action Token
+constTok t (LI sp _ _ _) _ ep = pure $! Token t sp ep
+
+onString :: (L.Text -> TokenClass) -> Action Token
+onString f (LI sp str _ _) len ep = pure $! Token (f (L.take len str)) sp ep
+
+lexTok :: (T.Text -> TokenClass) -> Action Token
+lexTok k (LI sp str _ _) len ep = pure (Token (k str') sp ep) where
+    str' = L.toStrict . L.take len $ str
+
+onStringM :: (L.Text -> Action a) -> Action a
+onStringM f p@(LI _ str _ _) len = (f (L.take len str)) p len
+
+-- | Consume a token from the input text without adding virtual
+-- "context" tokens.
+lexerScan :: Parser Token
+lexerScan = do
+  inp <- getInput
+  sc <- getStartCode
+  case alexScan inp sc of
+    AlexEOF -> do
+      start <- tokenStart <$> getState
+      code <- getStartCode
+      case code of
+        0 -> (\p -> Token TcEOF p p) <$> getPos
+        n | n == string -> failWith (UnclosedString (liPos inp) start)
+        _ -> failWith (UnexpectedEnd (liPos inp))
+    AlexError (LI p str _ _) ->
+      let ch = L.head str
+      in failWith (UnexpectedCharacter p ch)
+    AlexSkip  inp' _ -> do
+      setInput inp'
+      lexerScan
+    AlexToken inp' _ action -> do
+      setInput inp'
+      -- Determine when this token ends. For the sake of the argument, we
+      -- assume all tokens exist on a single line.
+      let ep = case liPos inp' of
+                 SourcePos { spCol = 1 } -> liPos inp
+                 SourcePos f l c -> SourcePos f l (c - 1)
+      action inp (liIdx inp' - liIdx inp) ep
+
+}

--- a/src/Language/Lua/Parser/Parser.y
+++ b/src/Language/Lua/Parser/Parser.y
@@ -1,0 +1,240 @@
+{
+{-| The parser for Lua, as defined by a Happy grammar.
+-}
+module Language.Lua.Parser.Parser
+  ( parseExpr
+  , parseStmt
+  , parseStmts
+  ) where
+
+import Control.Arrow (second)
+
+import Data.List (intercalate, nub)
+import Data.Maybe (fromJust, isJust)
+import qualified Data.Text as T
+
+import Language.Lua.Parser.Wrapper
+import Language.Lua.Parser.Error
+import Language.Lua.Parser.Lexer
+import Language.Lua.Parser.Token
+import Language.Lua.Syntax
+
+#undef __GLASGOW_HASKELL__
+#define __GLASGOW_HASKELL__ 709
+
+}
+
+%name parseExpr Expr
+%name parseStmt Stmt
+%name parseStmts Stmts
+
+%tokentype { Token }
+%monad { Parser } { (>>=) } { return }
+%lexer { lexer } { Token TcEOF _ _ }
+%error { parseError }
+%errorhandlertype explist
+
+%token
+  and      { Token TcAnd _ _ }
+  break    { Token TcBreak _ _ }
+  do       { Token TcDo _ _ }
+  else     { Token TcElse _ _ }
+  elseif   { Token TcElseIf _ _ }
+  end      { Token TcEnd _ _ }
+  false    { Token TcFalse _ _ }
+  for      { Token TcFor _ _ }
+  function { Token TcFunction _ _ }
+  if       { Token TcIf _ _ }
+  in       { Token TcIn _ _ }
+  local    { Token TcLocal _ _ }
+  nil      { Token TcNil _ _ }
+  not      { Token TcNot _ _ }
+  or       { Token TcOr _ _ }
+  repeat   { Token TcRepeat _ _ }
+  return   { Token TcReturn _ _ }
+  then     { Token TcThen _ _ }
+  true     { Token TcTrue _ _ }
+  until    { Token TcUntil _ _ }
+  while    { Token TcWhile _ _ }
+
+  ':'      { Token TcColon _ _ }
+  ','      { Token TcComma _ _ }
+  '.'      { Token TcDot _ _ }
+  '...'    { Token TcDots _ _ }
+  '='      { Token TcEquals _ _ }
+  ';'      { Token TcSemicolon _ _ }
+
+  '('      { Token TcOParen _ _ }
+  ')'      { Token TcCParen _ _ }
+  '{'      { Token TcOBrace _ _ }
+  '}'      { Token TcCBrace _ _ }
+  '['      { Token TcOSquare _ _ }
+  ']'      { Token TcCSquare _ _ }
+
+  '+'      { Token TcAdd _ _ }
+  '-'      { Token TcSub _ _ }
+  '*'      { Token TcMul _ _ }
+  '/'      { Token TcDiv _ _ }
+  '^'      { Token TcPow _ _ }
+  '%'      { Token TcMod _ _ }
+
+  '=='     { Token TCEq _ _ }
+  '~='     { Token TCNe _ _ }
+  '<'      { Token TcLt _ _ }
+  '>'      { Token TcGt _ _ }
+  '<='     { Token TcLe _ _ }
+  '>='     { Token TcGe _ _ }
+
+  ident    { Token (TcIdentifier _) _ _ }
+
+  qexpr    { Token (TcQuoteE _) _ _ }
+  qstmt    { Token (TcQuoteS _) _ _ }
+  qvar     { Token (TcQuoteV _) _ _ }
+
+  int      { Token (TcInteger _) _ _ }
+  float    { Token (TcFloat _) _ _ }
+  string   { Token (TcString  _) _ _ }
+
+%right '^'
+%right 'not' '#'
+%left '*' '/' '%'
+%left '+' '-'
+%right '..'
+%left '<' '>' '<=' '>=' '~=' '=='
+%left and
+%left or
+%%
+
+Ident :: { LuaVar }
+  : ident                               { LuaName (getIdent $1) }
+  | qvar                                { LuaQuoteV (getIdent $1) }
+
+Var :: { LuaVar }
+  : Ident                               { $1 }
+  | BaseExpr '.' ident                  { LuaIndex $1 (LuaRef . LuaName . getIdent $ $3) }
+  | BaseExpr '[' Expr ']'               { LuaIndex $1 $3 }
+
+BaseExpr :: { LuaExpr }
+  : Var                                 { LuaRef $1 }
+  | qexpr                               { LuaQuoteE (getIdent $1) }
+  | '(' Expr ')'                        { $2 }
+  | Call                                { $1 }
+
+Call :: { LuaExpr }
+  : BaseExpr '(' List(Expr, ',') ')'    { LuaCall $1 $3 }
+  | BaseExpr string                     { LuaCall $1 [LuaString (getString $2)] }
+  | BaseExpr Table                      { LuaCall $1 [$2] }
+  -- TODO: We should technically include foo:bar() here too
+
+Atom :: { LuaExpr }
+  : BaseExpr                            { $1 }
+  | Table                               { $1 }
+
+  | nil                                 { LuaNil }
+  | true                                { LuaTrue }
+  | false                               { LuaFalse }
+  | '...'                               { LuaDots }
+
+  | int                                 { LuaInteger (getInt $1) }
+  | float                               { LuaNumber (getFloat  $1) }
+  | string                              { LuaString (getString $1) }
+  | function '(' List(Ident, ',') ')' Stmts end { LuaFunction  $3 $5 }
+
+Expr :: { LuaExpr }
+  : Atom                                { $1 }
+
+  | Expr and Expr                       { LuaBinOp $1 (T.pack "and") $3 }
+  | Expr or  Expr                       { LuaBinOp $1 (T.pack "or")  $3 }
+
+  | Expr '+' Expr                       { LuaBinOp $1 (T.pack "+") $3 }
+  | Expr '-' Expr                       { LuaBinOp $1 (T.pack "-") $3 }
+  | Expr '*' Expr                       { LuaBinOp $1 (T.pack "*") $3 }
+  | Expr '/' Expr                       { LuaBinOp $1 (T.pack "/") $3 }
+  | Expr '^' Expr                       { LuaBinOp $1 (T.pack "^") $3 }
+  | Expr '%' Expr                       { LuaBinOp $1 (T.pack "%") $3 }
+
+  | Expr '==' Expr                      { LuaBinOp $1 (T.pack "==") $3 }
+  | Expr '~=' Expr                      { LuaBinOp $1 (T.pack "~=") $3 }
+  | Expr '<'  Expr                      { LuaBinOp $1 (T.pack "<")  $3 }
+  | Expr '>'  Expr                      { LuaBinOp $1 (T.pack ">")  $3 }
+  | Expr '<=' Expr                      { LuaBinOp $1 (T.pack "<=") $3 }
+  | Expr '>=' Expr                      { LuaBinOp $1 (T.pack ">=") $3 }
+  -- TODO: '-' and not
+
+Table :: { LuaExpr }
+  : '{' List(TablePair, ',') '}'        { LuaTable (buildTable $2) }
+
+TablePair :: { Either LuaExpr (LuaExpr, LuaExpr) }
+  : Expr                                { Left $1 }
+  | ident '=' Expr                      { Right (LuaString (getIdent $1), $3) }
+  | '[' Expr ']' '=' Expr               { Right ($2, $5) }
+
+Stmts :: { [LuaStmt] }
+  :                                     { [] }
+  | ';' Stmts                           { $2 }
+  | Stmt Stmts                          { $1 : $2 }
+
+Stmt :: { LuaStmt }
+  : qstmt                               { LuaQuoteS (getIdent $1) }
+  | Call                                { buildCallS $1 }
+
+  | do Stmts end                        { LuaDo $2 }
+  | List1(Var, ',') '=' List1(Expr, ',') { LuaAssign $1 $3 }
+  | while Expr do Stmts end             { LuaWhile $2 $4 }
+  | repeat Stmts until Expr             { LuaRepeat $2 $4 }
+  | if Expr then Stmts ElseIfs end      { LuaIfElse (($2,$4):$5) }
+  | for Ident '=' Expr ',' Expr do Stmts end          { LuaFornum $2 $4 $6 (LuaInteger 1) $8 }
+  | for Ident '=' Expr ',' Expr ',' Expr do Stmts end { LuaFornum $2 $4 $6 $8 $10 }
+  | for List1(Ident, ',') in List1(Expr, ',') do Stmts end { LuaFor $2 $4 $6 }
+  | local List1(Ident, ',') '=' List1(Expr, ',') { LuaLocal $2 $4 }
+  | return List1(Expr, ',')             { LuaReturn $2 }
+  | break                               { LuaBreak }
+
+ElseIfs :: { [(LuaExpr, [LuaStmt])] }
+  :                                     { [] }
+  | else Stmts                          { [(LuaTrue, $2)] }
+  | elseif Expr then Stmts ElseIfs      { ($2, $4):$5 }
+
+List(p, s)
+    : {- Empty -}       { [] }
+    | List1(p, s)       { $1 }
+
+List1(p, s)
+     : p                { [$1] }
+     | p s List1(p, s)  { $1 : $3 }
+
+{
+
+lexer :: (Token -> Parser a) -> Parser a
+lexer = (lexerScan >>=)
+
+parseError :: (Token, [String]) -> Parser a
+parseError (tok, exp) = failWith mainErr
+
+  where
+    mainErr = UnexpectedToken tok (nub (map unmap exp))
+
+    unmap :: String -> String
+    unmap "ident" = "identifier"
+    unmap "qexpr" = "quasi-quoted expression"
+    unmap "qstmt" = "quasi-quoted statement"
+    unmap "qvar"  = "quasi-quoted variable"
+    unmap x = x
+
+buildTable = go 1 where
+  go _ [] = []
+  go n (Left x:xs) = (LuaInteger n, x):go (n + 1) xs
+  go n (Right x:xs) = x:go n xs
+
+buildCallS (LuaCall f xs) = LuaCallS f xs
+
+getIdent (Token (TcIdentifier x) _ _) = x
+getIdent (Token (TcQuoteE x) _ _) = x
+getIdent (Token (TcQuoteS x) _ _) = x
+getIdent (Token (TcQuoteV x) _ _) = x
+
+getInt    (Token (TcInteger x) _ _)    = x
+getFloat  (Token (TcFloat x) _ _)      = x
+getString (Token (TcString  x) _ _)    = x
+
+}

--- a/src/Language/Lua/Parser/Token.hs
+++ b/src/Language/Lua/Parser/Token.hs
@@ -1,0 +1,141 @@
+module Language.Lua.Parser.Token where
+
+import Data.Text (unpack, Text)
+import Data.Position
+import Data.Spanned
+import Data.Span
+
+-- | The raw classification of a token without additional metadata. This
+-- is the underlying representation of what the lexer produces and the
+-- parser consumes.
+data TokenClass
+  = TcAnd      -- ^ An @and@ token.
+  | TcBreak    -- ^ A @break@ token.
+  | TcDo       -- ^ A @do@ token.
+  | TcElse     -- ^ An @else@ token.
+  | TcElseIf   -- ^ An @elseif@ token.
+  | TcEnd      -- ^ An @end@ token.
+  | TcFalse    -- ^ A @false@ token.
+  | TcFor      -- ^ A @for@ token.
+  | TcFunction -- ^ A @function@ .
+  | TcIf       -- ^ An @if@ token.
+  | TcIn       -- ^ An @in@ token.
+  | TcLocal    -- ^ A @local@ token.
+  | TcNil      -- ^ A @nil@ token.
+  | TcNot      -- ^ A @not@ token.
+  | TcOr       -- ^ An @or@ token.
+  | TcRepeat   -- ^ A @repeat@ token.
+  | TcReturn   -- ^ A @return@ token.
+  | TcThen     -- ^ A @then@ token.
+  | TcTrue     -- ^ A @true@ token.
+  | TcUntil    -- ^ A @until@ token.
+  | TcWhile    -- ^ A @while@ token.
+
+  | TcColon -- ^ A @:@ token.
+  | TcComma -- ^ A @,@ token.
+  | TcDot -- ^ A @.@ token.
+  | TcDots -- ^ A @...@ token.
+  | TcEquals -- ^ A @=@ token.
+  | TcSemicolon -- ^ A @;@ token.
+
+  | TcOParen -- ^ A @(@ token.
+  | TcCParen -- ^ A @)@ token.
+  | TcOBrace -- ^ A @{@ token.
+  | TcCBrace -- ^ A @}@ token.
+  | TcOSquare -- ^ A @[@ token.
+  | TcCSquare -- ^ A @]@ token.
+
+  | TcAdd | TcSub | TcMul | TcDiv | TcPow | TcMod
+
+  | TCEq | TCNe | TcLt | TcGt | TcLe | TcGe
+
+  | TcIdentifier Text -- ^ Identifiers (@foo@)
+
+  | TcQuoteE Text -- ^ Quoted expressions (@%foo@)
+  | TcQuoteS Text -- ^ Quoted statements (@\@foo()@)
+  | TcQuoteV Text -- ^ Quoted identifiers (@$foo@)
+
+  | TcInteger Int -- ^ Integer literal
+  | TcFloat Double -- ^ Floating-point literal
+  | TcString Text -- ^ String literal
+
+  | TcWhitespace Text -- ^ One of more whitespace characters, only appearing in lexing streams
+  | TcComment Text    -- ^ The body of a comment, including the `(*` and `*)`.
+
+  | TcEOF -- ^ End of file
+  deriving Eq
+
+instance Show TokenClass where
+  show TcAnd = "and"
+  show TcBreak = "break"
+  show TcDo = "do"
+  show TcElse = "else"
+  show TcElseIf = "elseif"
+  show TcEnd = "end"
+  show TcFalse = "false"
+  show TcFor = "for"
+  show TcFunction = "function"
+  show TcIf = "if"
+  show TcIn = "in"
+  show TcLocal = "local"
+  show TcNil = "nil"
+  show TcNot = "not"
+  show TcOr = "or"
+  show TcRepeat = "repeat"
+  show TcReturn = "return"
+  show TcThen = "then"
+  show TcTrue = "true"
+  show TcUntil = "until"
+  show TcWhile = "while"
+
+  show TcColon = ":"
+  show TcComma = ","
+  show TcDot = "."
+  show TcDots = "..."
+  show TcEquals = "="
+  show TcSemicolon = ";"
+
+  show TcOParen = "("
+  show TcCParen = ")"
+  show TcOBrace = "{"
+  show TcCBrace = "}"
+  show TcOSquare = "["
+  show TcCSquare = "]"
+
+  show TcAdd = "+"
+  show TcSub = "-"
+  show TcMul = "*"
+  show TcDiv = "/"
+  show TcPow = "^"
+  show TcMod = "%"
+
+  show TCEq = "=="
+  show TCNe = "~="
+  show TcLt = "<"
+  show TcGt = ">"
+  show TcLe = "<="
+  show TcGe = ">="
+
+  show (TcIdentifier t) = unpack t
+
+  show (TcQuoteE t) = '%':unpack t
+  show (TcQuoteS t) = '@':unpack t
+  show (TcQuoteV t) = '$':unpack t
+
+  show (TcString t) = show (unpack t)
+  show (TcInteger i) = show i
+  show (TcFloat i) = show i
+
+  show (TcWhitespace t) = concatMap escape (unpack t) where
+    escape '\t' = "\\t"
+    escape '\n' = "\\n"
+    escape c    = [c]
+  show (TcComment t) = unpack t
+
+  show TcEOF = "<eof>"
+
+-- | A token, with its class, start, and end position.
+data Token = Token !TokenClass !SourcePos !SourcePos deriving Show
+
+instance Spanned Token where
+  annotation (Token _ s e) = mkSpanUnsafe s e

--- a/src/Language/Lua/Parser/Wrapper.hs
+++ b/src/Language/Lua/Parser/Wrapper.hs
@@ -1,0 +1,184 @@
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+{-# LANGUAGE MultiParamTypeClasses, FlexibleInstances #-}
+
+{-| An alternative wrapper for the Alex lexer and Happy parser. This
+  operates on 'T.Text' objects instead of Alex's default bytestrings.
+
+  As the lexer and parser work in sync (we only consume one token at a
+  time), we must manage the state of both at the same time.
+-}
+module Language.Lua.Parser.Wrapper
+  ( SourcePos(..)
+  , Token(..)
+  , AlexInput(..)
+  , PState(..)
+  , Parser
+  , Action
+  , alexInputPrevChar, alexGetByte
+  , failWith
+  , getStartCode, setStartCode
+  , getInput, setInput
+  , getState, setState, mapState
+  , getPos
+  , runParser
+  ) where
+
+import Control.Monad.Fail as MonadFail
+import Control.Monad.Writer
+
+import qualified Data.Text.Lazy.Builder as B
+import qualified Data.Text.Lazy as L
+
+import Data.Word (Word8)
+import Data.Int (Int64)
+import Data.Char (ord)
+import Data.Position
+import Data.Spanned
+
+import Text.Pretty.Semantic
+
+import Language.Lua.Parser.Token
+import Language.Lua.Parser.Error
+
+-- | The current Alex input, for consumption by the lexer
+data AlexInput = LI { liPos  :: !SourcePos
+                    , liText :: !L.Text
+                    , liPrev :: !Char
+                    , liIdx  :: !Int64 }
+
+-- | The current state of the lexer and parser
+data PState = PState { stringBuffer :: B.Builder  -- ^ Builder for string literals
+                     , stringChar   :: Char       -- ^ The starting character for the string
+                     , tokenStart   :: !SourcePos -- ^ The position of the start of this token
+                     , trivials     :: Bool       -- ^ Whether "trivial" tokens such as whitespace and comments should be emitted.
+
+                     , sPos  :: !SourcePos -- ^ Current source position
+                     , sText :: !L.Text    -- ^ Current input
+                     , sPrev :: !Char      -- ^ Character before the input
+                     , sIdx  :: !Int64     -- ^ Offset into the whole input
+                     , sMode :: !Int       -- ^ Current startcode
+                     }
+
+-- | Extract the last consumed character
+alexInputPrevChar :: AlexInput -> Char
+alexInputPrevChar = liPrev
+
+-- | Get the current byte of the input. This will classify unicode
+-- characters using 'U.asFakeWord'.
+alexGetByte :: AlexInput -> Maybe (Word8, AlexInput)
+alexGetByte LI{ liPos = p, liText = t, liIdx = n } =
+  case L.uncons t of
+    Nothing -> Nothing
+    Just (c, t') ->
+      let b | c <= '\x7f' = fromIntegral (ord c)
+            | otherwise = 0 :: Word8
+      in Just (b, LI { liPos = alexMove p c
+                     , liText = t'
+                     , liPrev = c
+                     , liIdx = n + 1 })
+
+-- | Consume one character from the current input
+alexMove :: SourcePos -> Char -> SourcePos
+alexMove (SourcePos f l _) '\n' = SourcePos f (l + 1) 1
+alexMove (SourcePos f l c) _     = SourcePos f l (c + 1)
+
+-- | Represents the result of a parse operation
+data ParseResult a
+  -- | A successful operation, meaning parsing can continue
+  = POK PState a
+  -- | Parsing failed with an error.
+  | PFailed ParseError
+
+instance Show a => Show (ParseResult a) where
+  show (POK _ s) = "(POK" ++ show s ++ ")"
+  show (PFailed err) = "(PFailed " ++ show err ++ ")"
+
+instance Pretty a => Pretty (ParseResult a) where
+  pretty (POK _ s) = pretty s
+  pretty (PFailed e) = pretty (annotation e) <> string ":" <+> pretty e
+
+newtype Parser a = P { unP :: PState -> ParseResult a }
+
+instance Functor Parser where
+  fmap = liftM
+
+instance Applicative Parser where
+  pure a = a `seq` (P $ flip POK a)
+  (<*>) = ap
+
+instance Monad Parser where
+  (P m) >>= k = P $ \s -> case m s of
+    POK s' a -> unP (k a) s'
+    PFailed e -> PFailed e
+  fail = MonadFail.fail
+
+instance MonadFail Parser where
+  fail msg = P $ \s -> PFailed (Failure (sPos s) msg)
+
+-- | Abort the parse with an error
+failWith :: ParseError -> Parser a
+failWith e = P $ \_ -> PFailed e
+
+-- | Get the current start code for the lexer
+getStartCode :: Parser Int
+getStartCode = P $ \s -> POK s (sMode s)
+
+-- | Set the start code for the lexer
+setStartCode :: Int -> Parser ()
+setStartCode m = P $ \s -> POK (s { sMode = m }) ()
+
+-- | Get the current input for the lexer
+getInput :: Parser AlexInput
+getInput = P $ \s -> POK s LI { liPos  = sPos s
+                              , liText = sText s
+                              , liPrev = sPrev s
+                              , liIdx  = sIdx  s }
+
+-- | Set the current input for the lexer
+setInput :: AlexInput -> Parser ()
+setInput p = P $ \s -> POK (s { sPos  = liPos  p
+                              , sText = liText p
+                              , sPrev = liPrev p
+                              , sIdx  = liIdx  p }) ()
+
+-- | Get the current parser state
+getState :: Parser PState
+getState = P $ \s -> POK s s
+
+-- | Set the current parser state
+setState :: PState -> Parser ()
+setState s = P $ \_ -> POK s ()
+
+-- | Apply a function to the current parser state
+mapState :: (PState -> PState) -> Parser ()
+mapState f = P (flip POK () . f)
+
+-- | Get the current position in the input text
+getPos :: Parser SourcePos
+getPos = P $ \s -> POK s (sPos s)
+
+-- | An action performed by the lexer, which consumes the current input
+-- and produces some object (normally a token).
+type Action a = AlexInput -> Int64 -> SourcePos -> Parser a
+
+-- | Run the parser monad, returning the result and a list of errors and
+-- warnings
+runParser :: SourcePos -> L.Text -> Parser a -> Either ParseError a
+runParser = runParser' False
+
+runParser' :: Bool -> SourcePos -> L.Text -> Parser a -> Either ParseError a
+runParser' trivial pos input m =
+  let defaultState  = PState { stringBuffer = mempty
+                             , stringChar   = '\0'
+                             , tokenStart   = pos
+                             , trivials     = trivial
+
+                             , sPos  = pos
+                             , sText = input
+                             , sPrev = '\n'
+                             , sIdx  = 0
+                             , sMode = 0
+                             }
+  in case unP m defaultState of
+       PFailed err -> Left err
+       POK _ a -> Right a

--- a/src/Language/Lua/Quote.hs
+++ b/src/Language/Lua/Quote.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE TemplateHaskellQuotes, OverloadedStrings #-}
+module Language.Lua.Quote
+  ( lua
+  , luaStmt
+  , luaStmts
+  ) where
+
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as L
+import Data.Generics
+
+import qualified Language.Haskell.TH.Syntax as TH
+import qualified Language.Haskell.TH as TH
+import Language.Haskell.TH.Quote
+
+import Language.Lua.Parser.Wrapper
+import Language.Lua.Parser.Parser
+import Language.Lua.Syntax
+
+import qualified Text.Pretty.Note as N
+
+lua, luaStmt, luaStmts :: QuasiQuoter
+lua = luaQuote parseExpr
+luaStmt = luaQuote parseStmt
+luaStmts = luaQuote parseStmts
+
+luaQuote :: Data a => Parser a -> QuasiQuoter
+luaQuote parser = QuasiQuoter
+  { quoteExp = go
+  , quotePat = const (fail "Patterns not supported")
+  , quoteType = const (fail "Types not supported")
+  , quoteDec = const (fail "Declarations not supported")
+  } where
+  go s = do
+    loc <- TH.location
+    let (line, col)  = TH.loc_start loc
+        pos = SourcePos (TH.loc_filename loc) line col
+        spans = [( TH.loc_filename loc
+                 , T.replicate (line - 1) "\n" <> T.replicate (col - 1) " " <> T.pack s)]
+    case runParser pos (L.pack s) parser of
+      Right res -> antiLua res
+      Left e -> fail . show . N.format (N.fileSpans spans) $ e
+
+antiLua ::  Data a => a -> TH.Q TH.Exp
+antiLua = dataToExpQ (const Nothing `extQ` antiExpr `extQ` antiStmt `extQ` antiVar `extQ` liftText)
+
+antiExpr :: LuaExpr -> Maybe (TH.Q TH.Exp)
+antiExpr (LuaQuoteE x) = Just $ TH.varE  (TH.mkName (T.unpack x))
+antiExpr _ = Nothing
+
+antiVar :: LuaVar -> Maybe (TH.Q TH.Exp)
+antiVar (LuaQuoteV x) = Just $ TH.varE  (TH.mkName (T.unpack x))
+antiVar _ = Nothing
+
+antiStmt :: LuaStmt -> Maybe (TH.Q TH.Exp)
+antiStmt (LuaQuoteS x) = Just $ TH.varE  (TH.mkName (T.unpack x))
+antiStmt _ = Nothing
+
+liftText :: T.Text -> Maybe (TH.Q TH.Exp)
+liftText txt = Just $ TH.AppE (TH.VarE 'T.pack) <$> TH.lift (T.unpack txt)

--- a/src/Language/Lua/Quote.hs
+++ b/src/Language/Lua/Quote.hs
@@ -26,35 +26,48 @@ luaStmts = luaQuote parseStmts
 
 luaQuote :: Data a => Parser a -> QuasiQuoter
 luaQuote parser = QuasiQuoter
-  { quoteExp = go
-  , quotePat = const (fail "Patterns not supported")
+  { quoteExp = go (dataToExpQ (antis TH.varE liftTE))
+  , quotePat = go (dataToPatQ (antis TH.varP liftTP))
   , quoteType = const (fail "Types not supported")
   , quoteDec = const (fail "Declarations not supported")
   } where
-  go s = do
+
+  go build s = do
     loc <- TH.location
     let (line, col)  = TH.loc_start loc
         pos = SourcePos (TH.loc_filename loc) line col
         spans = [( TH.loc_filename loc
                  , T.replicate (line - 1) "\n" <> T.replicate (col - 1) " " <> T.pack s)]
     case runParser pos (L.pack s) parser of
-      Right res -> antiLua res
+      Right res -> build res
       Left e -> fail . show . N.format (N.fileSpans spans) $ e
 
-antiLua ::  Data a => a -> TH.Q TH.Exp
-antiLua = dataToExpQ (const Nothing `extQ` antiExpr `extQ` antiStmt `extQ` antiVar `extQ` liftText)
+  antis var other =
+    const Nothing
+    `extQ` antiExpr var
+    `extQ` antiStmt var
+    `extQ` antiVar var
+    `extQ` other
 
-antiExpr :: LuaExpr -> Maybe (TH.Q TH.Exp)
-antiExpr (LuaQuoteE x) = Just $ TH.varE  (TH.mkName (T.unpack x))
-antiExpr _ = Nothing
+  liftTE :: T.Text -> Maybe (TH.Q TH.Exp)
+  liftTE = Just . liftText
 
-antiVar :: LuaVar -> Maybe (TH.Q TH.Exp)
-antiVar (LuaQuoteV x) = Just $ TH.varE  (TH.mkName (T.unpack x))
-antiVar _ = Nothing
+  liftTP :: T.Text -> Maybe (TH.Q TH.Pat)
+  liftTP txt = Just $ do
+    txt' <- liftText txt
+    pure (TH.ViewP (TH.AppE (TH.VarE '(==)) txt') (TH.ConP 'True []))
 
-antiStmt :: LuaStmt -> Maybe (TH.Q TH.Exp)
-antiStmt (LuaQuoteS x) = Just $ TH.varE  (TH.mkName (T.unpack x))
-antiStmt _ = Nothing
+antiExpr :: (TH.Name -> TH.Q a) -> LuaExpr -> Maybe (TH.Q a)
+antiExpr var (LuaQuoteE x) = Just $ var . TH.mkName . T.unpack $ x
+antiExpr _ _ = Nothing
 
-liftText :: T.Text -> Maybe (TH.Q TH.Exp)
-liftText txt = Just $ TH.AppE (TH.VarE 'T.pack) <$> TH.lift (T.unpack txt)
+antiVar :: (TH.Name -> TH.Q a) -> LuaVar -> Maybe (TH.Q a)
+antiVar var (LuaQuoteV x) = Just $ var . TH.mkName . T.unpack $ x
+antiVar _ _ = Nothing
+
+antiStmt :: (TH.Name -> TH.Q a) -> LuaStmt -> Maybe (TH.Q a)
+antiStmt var (LuaQuoteS x) = Just . var . TH.mkName . T.unpack $ x
+antiStmt _ _ = Nothing
+
+liftText :: T.Text -> TH.Q TH.Exp
+liftText txt = TH.AppE (TH.VarE 'T.pack) <$> TH.lift (T.unpack txt)

--- a/src/Language/Lua/Syntax.hs
+++ b/src/Language/Lua/Syntax.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Backend.Lua.Syntax
+module Language.Lua.Syntax
   ( LuaStmt(..)
   , LuaVar(..)
   , LuaExpr(..)

--- a/tests/lua/and.lua
+++ b/tests/lua/and.lua
@@ -4,7 +4,12 @@ do
     if x[2] then
       return x[1]
     else
-      x[1], x[2] = x[1](__builtin_unit), true
+      local thunk = x[1]
+      x[1] = function()
+        error("loop while forcing thunk")
+      end
+      x[1] = thunk(__builtin_unit)
+      x[2] = true
       return x[1]
     end
   end

--- a/tests/lua/match_consumed.lua
+++ b/tests/lua/match_consumed.lua
@@ -6,7 +6,6 @@ do
   local a = bottom(1)
   if bottom.__tag == "None" then
     bottom(bottom(a))
-
   elseif bottom.__tag == "Some" then
     bottom(bottom(a + bottom[1] * 2))
   end


### PR DESCRIPTION
This adds a couple of things:

 - A parser for a subset of Lua. Our `Language.Lua.Syntax` data structures are missing a couple of things (namely `not`, `-`, `local function` and `foo:bar()`) so we do not yet parse those.
 - A Template Haskell quasi-quoter for Lua expressions and statements. One can use `$foo` to substitute variables, `%foo` for expressions and `@foo` for statements.
 - Replaces some of the more complex expressions in `Backend.Lua.Postprocess` with their quasi-quoted alternatives.