### PR TITLE
Convert native definitions to use unboxed tuples within Lower

### DIFF
--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -653,23 +653,7 @@ emitStmt (Foreign n t s:xs) = do
                   , topVars = VarMap.insert (toVar n) [LuaName n'] (topVars s) })
 
   let Right ex = runParser (SourcePos "_" 0 0) (s ^. lazy) parseExpr
-      stmts = if arity t > 1
-              then
-                let ags = map LuaName $ take (arity t) alpha
-                    mkF (a:ag) bd = LuaFunction [a] [LuaReturn [mkF ag bd]]
-                    mkF [] bd = bd
-                in LuaLocal [LuaName (T.cons '_' n')] [ex]
-                <| LuaLocal [LuaName n']
-                     [mkF ags
-                      (LuaCall (LuaRef (LuaName (T.cons '_' n')))
-                       (map LuaRef ags))]
-                <| mempty
-              else LuaLocal [LuaName n'] [ex] <| mempty
-
-  (stmts<>) <$> emitStmt xs
-
-  where alpha :: [T.Text]
-        alpha = map T.pack ([1..] >>= flip replicateM ['a'..'z'])
+  (LuaLocal [LuaName n'] [ex]<|) <$> emitStmt xs
 
 emitStmt (Type _ cs:xs) = do
   stmts <- foldr (<|) mempty <$> traverse emitConstructor cs

--- a/tests/lua/external.lua
+++ b/tests/lua/external.lua
@@ -1,7 +1,6 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
-  local _rem = function(x, y) return x % y end
-  local rem = function(a) return function(b) return _rem(a, b) end end
+  local rem = function(x, y) return x % y end
   local bottom = nil
-  bottom(rem(5)(3))
+  bottom(rem(5, 3))
 end


### PR DESCRIPTION
This allows more optimisation opportunities. In the future, when annotations are added to the syntax, we will be able to handle how these are lowered more granularly.