### PR TITLE
Reducer rewrite 3: Inliner heurstics

### DIFF
--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -43,20 +43,20 @@ substitute m = term where
   arm = armBody %~ term
 
 -- | Substitute a type variable with some other type inside terms
-substituteInTys :: forall a. IsVar a => VarMap.Map (Type a) -> Term a -> Term a
+substituteInTys :: forall a b. IsVar a => VarMap.Map (Type a) -> AnnTerm b a -> AnnTerm b a
 substituteInTys = term where
-  term :: VarMap.Map (Type a) -> Term a -> Term a
+  term :: VarMap.Map (Type a) -> AnnTerm b a -> AnnTerm b a
   term m a | VarMap.null m = a
-  term m (Atom a) = Atom (atom m a)
-  term m (App f x) = App (atom m f) (atom m x)
-  term m (Let (One (v, t, e)) x) = Let (One (v, gotype m t, term m e)) (term m x)
-  term m (Let (Many vs) x) = Let (Many (map (trimap id (gotype m) (term m)) vs)) (term m x)
-  term m (Match x vs) = Match (atom m x) (map (arm m) vs)
-  term m (Extend e rs) = Extend (atom m e) (map (trimap id (gotype m) (atom m)) rs)
-  term m (Values xs) = Values (map (atom m) xs)
-  term m (TyApp f t) = TyApp (atom m f) (gotype m t)
-  term m (Cast f t) = Cast (atom m f) (coercion m t)
-  term m (Lam arg b) = Lam (go arg) (term (delete m) b) where
+  term m (AnnAtom z a) = AnnAtom z (atom m a)
+  term m (AnnApp z f x) = AnnApp z (atom m f) (atom m x)
+  term m (AnnLet z (One (v, t, e)) x) = AnnLet z (One (v, gotype m t, term m e)) (term m x)
+  term m (AnnLet z (Many vs) x) = AnnLet z (Many (map (trimap id (gotype m) (term m)) vs)) (term m x)
+  term m (AnnMatch z x vs) = AnnMatch z (atom m x) (map (arm m) vs)
+  term m (AnnExtend z e rs) = AnnExtend z (atom m e) (map (trimap id (gotype m) (atom m)) rs)
+  term m (AnnValues z xs) = AnnValues z (map (atom m) xs)
+  term m (AnnTyApp z f t) = AnnTyApp z (atom m f) (gotype m t)
+  term m (AnnCast z f t) = AnnCast z (atom m f) (coercion m t)
+  term m (AnnLam z arg b) = AnnLam z (go arg) (term (delete m) b) where
     go (TermArgument v t) = TermArgument v (gotype m t)
     go (TypeArgument v t) = TypeArgument v (gotype m t)
     delete = case arg of

--- a/src/Core/Optimise/Reduce.hs
+++ b/src/Core/Optimise/Reduce.hs
@@ -74,15 +74,15 @@ reduceStmts (Foreign v ty def:ss) = do
   ss' <- local (ariScope %~ flip extendForeign (v, ty)) (reduceStmts ss)
   pure (Foreign (underlying v) (underlying <$> ty) def:ss')
 reduceStmts (StmtLet (One var):ss) = do
-  var' <- mapVar reduceTerm var
+  var' <- mapVar reduceTerm' var
   ss' <- local (extendVar var') (reduceStmts ss)
   pure $ StmtLet (One var'):ss'
 reduceStmts (StmtLet (Many vs):ss) = local (ariScope %~ flip extendPureLets vs) $ do
   breakers <- asks (flip loopBreakers vs)
 
-  vsn <- traverse (mapVar reduceTerm) . filter (flip VarSet.notMember breakers . toVar . fst3) $ vs
+  vsn <- traverse (mapVar reduceTerm') . filter (flip VarSet.notMember breakers . toVar . fst3) $ vs
   local (extendVars vsn . extendBreakers breakers) $ do
-    vse <- traverse (mapVar reduceTerm) . filter (flip VarSet.member breakers . toVar . fst3) $ vs
+    vse <- traverse (mapVar reduceTerm') . filter (flip VarSet.member breakers . toVar . fst3) $ vs
     ss' <- local (extendVarsRec vse) $ reduceStmts ss
     pure (StmtLet (Many (vse ++ vsn)):ss')
 reduceStmts (Type v cases:ss) = do
@@ -97,8 +97,10 @@ reduceStmts (Type v cases:ss) = do
 -- | Simplify an atom within the current context
 --
 -- This doesn't do anything fancy: we just inline trivial variables.
-reduceAtom :: MonadReduce a m => Atom (OccursVar a) -> m (Atom a)
-reduceAtom (Ref v ty) = do
+reduceAtom :: MonadReduce a m
+           => UsedAs -> Atom (OccursVar a)
+           -> m (Atom a)
+reduceAtom u (Ref v ty) = do
   -- Beta reduction (let case)
   v' <- asks (lookupTerm v)
   case v' of
@@ -110,7 +112,7 @@ reduceAtom (Ref v ty) = do
       s <- gets (VarMap.lookup (toVar v) . view varSubst)
       case s of
         Just (SubTodo t) -> do
-          t' <- reduceTerm t
+          t' <- reduceTerm u t
           case t' of
             Atom a -> do
               -- If this is just an atom, remove it from the substitution scope and
@@ -124,20 +126,26 @@ reduceAtom (Ref v ty) = do
         _ -> pure basic
   where basic = (Ref (underlying v) (underlying <$> ty))
 
-reduceAtom (Lit l) = pure (Lit l)
+reduceAtom _ (Lit l) = pure (Lit l)
+
+-- | Reduce an atom with the default context
+reduceAtom' :: MonadReduce a m
+            => Atom (OccursVar a)
+            -> m (Atom a)
+reduceAtom' = reduceAtom UsedOther
 
 -- | Simplify a term within the current context
 --
 -- This will simplify nested terms/atoms as well.
 reduceTerm :: forall a m. MonadReduce a m
-           => AnnTerm VarSet.Set (OccursVar a)
+           => UsedAs -> AnnTerm VarSet.Set (OccursVar a)
            -> m (Term a)
 
-reduceTerm (AnnAtom _ a) = Atom <$> reduceAtom a
-reduceTerm (AnnValues _ vs) = Values <$> traverse reduceAtom vs
+reduceTerm u (AnnAtom _ a) = Atom <$> reduceAtom u a
+reduceTerm _ (AnnValues _ vs) = Values <$> traverse reduceAtom' vs
 
-reduceTerm (AnnExtend _ e fs) = do
-  e' <- reduceAtom e
+reduceTerm _ (AnnExtend _ e fs) = do
+  e' <- reduceAtom' e
   fs' <- traverse reduceRow fs
   case fs' of
     -- Eliminate empty extensions
@@ -147,10 +155,10 @@ reduceTerm (AnnExtend _ e fs) = do
     [] -> changed $ Atom e'
     _ -> pure $ Extend e' fs'
   where
-    reduceRow (t, ty, e) = (t, underlying <$> ty, ) <$> reduceAtom e
+    reduceRow (t, ty, e) = (t, underlying <$> ty, ) <$> reduceAtom' e
 
-reduceTerm (AnnLam _ arg body) = do
-  body' <- reduceTerm body
+reduceTerm _ (AnnLam _ arg body) = do
+  body' <- reduceTerm' body
   s <- ask
   case (underlying <$> arg, body') of
     -- Eta conversion (function case)
@@ -167,8 +175,8 @@ reduceTerm (AnnLam _ arg body) = do
     nonBreaker (Ref v _) s = not . varLoopBreak . lookupVar v $ s
     nonBreaker Lit{} _ = True
 
-reduceTerm (AnnCast _ a co) = do
-  a' <- reduceAtom a
+reduceTerm u (AnnCast _ a co) = do
+  a' <- reduceAtom u a
   if redundantCo co
   then changed $ Atom a'
   else do
@@ -191,10 +199,16 @@ reduceTerm (AnnCast _ a co) = do
 
       | otherwise -> pure $ Cast a' co'
 
-reduceTerm t@AnnMatch{} = reduceTermK t pure
-reduceTerm t@AnnLet{}   = reduceTermK t pure
-reduceTerm t@AnnApp{}   = reduceTermK t pure
-reduceTerm t@AnnTyApp{} = reduceTermK t pure
+reduceTerm u t@AnnMatch{} = reduceTermK u t pure
+reduceTerm u t@AnnLet{}   = reduceTermK u t pure
+reduceTerm u t@AnnApp{}   = reduceTermK u t pure
+reduceTerm u t@AnnTyApp{} = reduceTermK u t pure
+
+-- | Reduce a term with the default context
+reduceTerm' :: MonadReduce a m
+            => AnnTerm VarSet.Set (OccursVar a)
+            -> m (Term a)
+reduceTerm' = reduceTerm UsedOther
 
 -- | Reduce the provided term, running the continuation when reaching the
 -- "leaf" node.
@@ -202,16 +216,17 @@ reduceTerm t@AnnTyApp{} = reduceTermK t pure
 -- This allows us to implement commuting conversion for lets and matches
 -- in a more intuitive manner.
 reduceTermK :: forall a m. MonadReduce a m
-            => AnnTerm VarSet.Set (OccursVar a)
+            => UsedAs
+            -> AnnTerm VarSet.Set (OccursVar a)
             -> (Term a -> m (Term a))
             -> m (Term a)
 
-reduceTermK d@(AnnApp _ f x) cont
-  = inlineOr d UsedOther cont basic
+reduceTermK u d@(AnnApp _ f x) cont
+  = inlineOr d u cont basic
   where
     basic = do
-      f' <- reduceAtom f
-      x' <- reduceAtom x
+      f' <- reduceAtom UsedApply f
+      x' <- reduceAtom' x
       s <- ask
       if
         -- Constant folding
@@ -224,18 +239,18 @@ reduceTermK d@(AnnApp _ f x) cont
         -- Nothing to do
         | otherwise -> cont (App f' x')
 
-reduceTermK d@(AnnTyApp _ f t) cont
+reduceTermK _ d@(AnnTyApp _ f t) cont
   = inlineOr d UsedOther cont basic
   where
     basic = do
-      f' <- reduceAtom f
+      f' <- reduceAtom UsedApply f
       cont $ TyApp f' (underlying <$> t)
 
-reduceTermK (AnnLet fa (One (va, tya, AnnLet fb bb rb)) ra) cont =
+reduceTermK u (AnnLet fa (One (va, tya, AnnLet fb bb rb)) ra) cont =
   -- TODO: Can we avoid this?
-  flip reduceTermK cont $ AnnLet fb bb (AnnLet fa (One (va, tya, rb)) ra)
+  flip (reduceTermK u) cont $ AnnLet fb bb (AnnLet fa (One (va, tya, rb)) ra)
 
-reduceTermK (AnnLet _ (One b@(v, ty, e)) rest) cont = do
+reduceTermK u (AnnLet _ (One b@(v, ty, e)) rest) cont = do
   s <- ask
   let used = usedWhen v
       pures = isPure (s ^. ariScope) e
@@ -251,12 +266,12 @@ reduceTermK (AnnLet _ (One b@(v, ty, e)) rest) cont = do
         _ -> False
 
   if
-    | used == Dead, pures -> reduceTermK rest cont
+    | used == Dead, pures -> reduceTermK u rest cont
     | inlines -> do
       varSubst %= VarMap.insert (toVar v) (SubTodo e)
 
       rest' <- local (ariScope %~ flip extendPureLets [b])
-                 (reduceTermK rest cont)
+                 (reduceTermK u rest cont)
 
       se <- gets (VarMap.lookup (toVar v) . view varSubst)
       varSubst %= VarMap.delete (toVar v)
@@ -265,9 +280,9 @@ reduceTermK (AnnLet _ (One b@(v, ty, e)) rest) cont = do
         -- If it's no longer in the set, then it's either been visited or is now
         -- considered dead.
         _ -> changed rest'
-    | otherwise -> reduceTermK e $ \e' -> do
+    | otherwise -> reduceTermK UsedOther e $ \e' -> do
       considerE e' (local (extendVar (v', ty', e'))
-                     (reduceTermK rest cont))
+                     (reduceTermK u rest cont))
 
   where
     v' = underlying v
@@ -333,32 +348,32 @@ reduceTermK (AnnLet _ (One b@(v, ty, e)) rest) cont = do
 
         | otherwise -> pure (Let (One (v', ty', e')) rest')
 
-reduceTermK (AnnLet f (Many vs) rest) cont =
+reduceTermK u (AnnLet f (Many vs) rest) cont =
   case stronglyConnComp . map buildNode $ vs of
-    [] -> reduceTermK rest cont
+    [] -> reduceTermK u rest cont
     [CyclicSCC vs] -> local (ariScope %~ flip extendPureLets vs) $ do
       breakers <- asks (flip loopBreakers vs)
       -- We go over the non-loop breakers (which will never be inlined), reduce
       -- them and then visit the loop breakers with these inlinable functions in
       -- scope.
-      vsn <- traverse (mapVar reduceTerm) . filter (flip VarSet.notMember breakers . toVar . fst3) $ vs
+      vsn <- traverse (mapVar reduceTerm') . filter (flip VarSet.notMember breakers . toVar . fst3) $ vs
       local (extendVars vsn . extendBreakers breakers) $ do
-        vse <- traverse (mapVar reduceTerm) . filter (flip VarSet.member breakers . toVar . fst3) $ vs
-        rest' <- local (extendVarsRec vse) $ reduceTermK rest cont
+        vse <- traverse (mapVar reduceTerm') . filter (flip VarSet.member breakers . toVar . fst3) $ vs
+        rest' <- local (extendVarsRec vse) $ reduceTermK u rest cont
         pure (Let (Many (vse ++ vsn)) rest')
 
     -- If we can split the nodes up into something simpler, do so!
     cs -> do
       cs' <- changed $ foldr unwrapNode rest cs
-      reduceTermK cs' cont
+      reduceTermK u cs' cont
 
   where
     buildNode n@(v, _, e) = (n, toVar v, VarSet.toList (extractAnn e))
     unwrapNode (AcyclicSCC v) = AnnLet f (One v)
     unwrapNode (CyclicSCC vs) = AnnLet f (Many vs)
 
-reduceTermK (AnnMatch _ test arms) cont = do
-  test' <- reduceAtom test
+reduceTermK _ (AnnMatch _ test arms) cont = do
+  test' <- reduceAtom UsedMatch test
   s <- ask
 
   -- We prune our pattern list, either removing the match if we can
@@ -410,7 +425,7 @@ reduceTermK (AnnMatch _ test arms) cont = do
 
     reduceBody :: (Term a -> m (Term a)) -> Subst a -> AnnTerm VarSet.Set (OccursVar a) -> m (Term a)
     reduceBody cont subst body =
-      local (varScope %~ VarMap.union (buildSub subst)) (reduceTermK body cont)
+      local (varScope %~ VarMap.union (buildSub subst)) (reduceTermK UsedOther body cont)
 
     buildSub :: Subst a -> VarMap.Map (VarDef a)
     buildSub = VarMap.fromList . map (\(var, a) -> (toVar var, basicDef var (Atom a)))
@@ -425,7 +440,7 @@ reduceTermK (AnnMatch _ test arms) cont = do
       let aty = approximateAtomType a
       unifyWith sol vty aty
 
-reduceTermK t cont = reduceTerm t >>= cont
+reduceTermK u t cont = reduceTerm u t >>= cont
 
 inlineOr :: MonadReduce a m
          => AnnTerm VarSet.Set (OccursVar a)
@@ -441,13 +456,13 @@ inlineOr t usage cont def = do
   case inline of
     Just (Left inl, rs) -> do
       VarSet.foldr (\v -> (*>) (varSubst %= VarMap.delete v)) (pure ()) rs
-      changing $ reduceTermK (buildKnownInline inl) cont
+      changing $ reduceTermK usage (buildKnownInline inl) cont
     Just (Right inl, rs)
       | shouldInline s st usage inl
       -> do
           VarSet.foldr (\v -> (*>) (varSubst %= VarMap.delete v)) (pure ()) rs
           rhs' <- refresh $ buildUnknownInline inl
-          changing $ reduceTermK (annotate rhs') cont
+          changing $ reduceTermK usage (annotate rhs') cont
     _ -> def
 
 redundantCo :: IsVar a => Coercion a -> Bool

--- a/src/Core/Optimise/Reduce.hs
+++ b/src/Core/Optimise/Reduce.hs
@@ -439,10 +439,13 @@ inlineOr t usage cont def = do
   st <- get
 
   case inline of
-    Just (Left inl) -> changing $ reduceTermK (buildKnownInline inl) cont
-    Just (Right inl)
+    Just (Left inl, rs) -> do
+      VarSet.foldr (\v -> (*>) (varSubst %= VarMap.delete v)) (pure ()) rs
+      changing $ reduceTermK (buildKnownInline inl) cont
+    Just (Right inl, rs)
       | shouldInline s st usage inl
       -> do
+          VarSet.foldr (\v -> (*>) (varSubst %= VarMap.delete v)) (pure ()) rs
           rhs' <- refresh $ buildUnknownInline inl
           changing $ reduceTermK (annotate rhs') cont
     _ -> def

--- a/src/Core/Optimise/Reduce/Base.hs
+++ b/src/Core/Optimise/Reduce/Base.hs
@@ -54,8 +54,8 @@ data DefInfo a
 -- | A definition within the current scope
 data VarDef a
   = VarDef
-  { varDef      :: Maybe (DefInfo a)
-  , varNotAmong :: [Pattern a]
+  { varDef       :: Maybe (DefInfo a)
+  , varNotAmong  :: [Pattern a]
   , varLoopBreak :: !Bool
   }
   deriving (Show)

--- a/src/Core/Optimise/Reduce/Inline.hs
+++ b/src/Core/Optimise/Reduce/Inline.hs
@@ -283,7 +283,7 @@ gatherInlining (AnnApp _ (Ref f _) x) = do
           Just ( Left ((v, x):vs, ts, bod)
                , VarSet.insert (toVar f) rs )
         Just (Right (vs, ts, Lam (TermArgument v _) bod), rs) ->
-          Just (  Right $ ((v, x):vs, ts, bod)
+          Just (  Right ((v, x):vs, ts, bod)
                , VarSet.insert (toVar f) rs )
         _ -> Nothing
     _ -> do
@@ -291,7 +291,7 @@ gatherInlining (AnnApp _ (Ref f _) x) = do
       pure $ case s of
         VarDef { varDef = Just DefInfo { defTerm = Lam (TermArgument v _) bod }
                , varLoopBreak = False }
-          -> Just ( Right $ ([(v, x)], mempty, bod)
+          -> Just ( Right ([(v, x)], mempty, bod)
                   , mempty )
         _ -> Nothing
 gatherInlining (AnnTyApp _ (Ref f _) x) = do

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -28,6 +28,7 @@ optmOnce = passes where
 
            , linted "Sinking" $ pure . sinkingPass . tagFreeSet
 
+           , linted "CSE" (pure . csePass)
            , linted "Reduce #2" reducePass
            ]
 
@@ -39,7 +40,7 @@ linted pass fn
 
 -- | Run the optimiser multiple times over the input core.
 optimise :: [Stmt CoVar] -> Namey [Stmt CoVar]
-optimise = postpasses <=< go 10 <=< prepasses . (runLint "Lower" =<< checkStmt emptyScope) where
+optimise = go 10 <=< prepasses . (runLint "Lower" =<< checkStmt emptyScope) where
   go :: Integer -> [Stmt CoVar] -> Namey [Stmt CoVar]
   go k sts
     | k > 0 = go (k - 1) =<< optmOnce sts
@@ -47,6 +48,3 @@ optimise = postpasses <=< go 10 <=< prepasses . (runLint "Lower" =<< checkStmt e
 
   prepasses :: [Stmt CoVar] -> Namey [Stmt CoVar]
   prepasses = linted "Newtype" killNewtypePass
-
-  postpasses :: [Stmt CoVar] -> Namey [Stmt CoVar]
-  postpasses = linted "CSE" (pure . csePass)

--- a/src/Data/VarMap.hs
+++ b/src/Data/VarMap.hs
@@ -1,20 +1,21 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, DerivingStrategies, FlexibleInstances, TypeFamilies #-}
 module Data.VarMap
   ( Map
-  , fromList, toList, null
+  , fromList, toList, null, size
   , lookup, member, findWithDefault
   , insert, delete
   , map, mapWithKey, singleton, union, unionSemigroup
   , alter
   , difference, intersection
-  , foldrWithKey
+  , foldrWithKey, foldr
   , (<>), mempty
   ) where
 
 import Control.Lens (At(..), Ixed(..), Index, IxValue)
 import qualified Data.HashMap.Strict as Map
+import qualified Prelude as P
 import Data.Coerce
-import Prelude hiding (lookup, map, null)
+import Prelude hiding (lookup, map, null, foldr)
 
 import Core.Var
 
@@ -26,6 +27,9 @@ newtype Map a
 null :: Map a -> Bool
 null (Map m) = Map.null m
 
+size :: Map a -> Int
+size (Map m) = Map.size m
+
 insert :: CoVar -> a -> Map a -> Map a
 insert x v (Map k) = Map (Map.insert x v k)
 
@@ -33,7 +37,7 @@ delete :: CoVar -> Map a -> Map a
 delete x (Map k) = Map (Map.delete x k)
 
 fromList :: [(CoVar, a)] -> Map a
-fromList = foldr (uncurry insert) mempty
+fromList = P.foldr (uncurry insert) mempty
 
 toList :: Map a -> [(CoVar, a)]
 toList (Map m) = Map.toList m
@@ -73,6 +77,9 @@ unionSemigroup (Map l) (Map r) = Map (Map.unionWith (<>) l r)
 
 foldrWithKey :: (CoVar -> a -> b -> b) -> b -> Map a -> b
 foldrWithKey f b (Map m) = Map.foldrWithKey f b m
+
+foldr :: (a -> b -> b) -> b -> Map a -> b
+foldr f b (Map m) = Map.foldr f b m
 
 type instance Index (Map a) = CoVar
 type instance IxValue (Map a) = a

--- a/src/Data/VarSet.hs
+++ b/src/Data/VarSet.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving, DerivingStrategies, FlexibleInstances #-}
 module Data.VarSet
   ( Set
+  , null, size
   , fromList, toList, singleton
   , foldr, filter
   , member, notMember
@@ -12,7 +13,7 @@ module Data.VarSet
 import qualified Data.HashSet as Set
 import qualified Data.List as L
 
-import Prelude hiding (foldr, filter)
+import Prelude hiding (foldr, filter, null)
 
 import Core.Var
 
@@ -22,6 +23,12 @@ newtype Set
   = Set (Set.HashSet CoVar)
   deriving (Eq, Show, Ord)
   deriving newtype (Semigroup, Monoid)
+
+null :: Set -> Bool
+null (Set s) = Set.null s
+
+size :: Set -> Int
+size (Set x) = Set.size x
 
 insert :: CoVar -> Set -> Set
 insert x (Set k) = Set (Set.insert x k)

--- a/tests/lua/as_pattern.lua
+++ b/tests/lua/as_pattern.lua
@@ -1,8 +1,9 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
-  local bottom = nil
-  bottom(function(cb)
+  local function main(cb)
     local b = cb.a
     return b.a + b.b + cb.c
-  end)
+  end
+  local bottom = nil
+  bottom(main)
 end

--- a/tests/lua/cse.lua
+++ b/tests/lua/cse.lua
@@ -1,7 +1,6 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
   local print = print
-  local x = 1
-  print(x)
-  print(x)
+  print(1)
+  print(1)
 end

--- a/tests/lua/let_pattern.lua
+++ b/tests/lua/let_pattern.lua
@@ -1,8 +1,6 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
   local du = { _1 = function(x) return x end, _2 = function(x) return x end }
-  local d = du._1
-  local e = du._2
   local bottom = nil
-  bottom({ a = 3, b = 5, c = 6, d = d, e = e })
+  bottom({ a = 3, b = 5, c = 6, d = du._1, e = du._2 })
 end

--- a/tests/lua/match_heuristic.lua
+++ b/tests/lua/match_heuristic.lua
@@ -32,35 +32,32 @@ do
       return error("Pattern matching failure in match expression at match_heuristic.ml[8:21 ..8:28]")
     end
   end
-  local bottom = nil
-  bottom({
-    common_prefix = common_prefix,
-    common_suffix = common_suffix,
-    mixed_1 = function(l)
-      local eq = l._2
-      local et = eq._2
-      local eu = eq._1
-      if l._1 then
-        if 1 == eu then
-          return 1
-        else
-          if et.__tag == "Cons" then
-            return 3
-          else
-            return error("Pattern matching failure in match expression at match_heuristic.ml[13:15 ..13:22]")
-          end
-        end
+  local function mixed_1(l)
+    local eq = l._2
+    local eu = eq._1
+    local et = eq._2
+    if l._1 then
+      if 1 == eu then
+        return 1
       else
-        if et.__tag == "Nil" then
-          if 2 == eu then
-            return 2
-          else
-            return error("Pattern matching failure in match expression at match_heuristic.ml[13:15 ..13:22]")
-          end
-        elseif et.__tag == "Cons" then
+        if et.__tag == "Cons" then
           return 3
+        else
+          return error("Pattern matching failure in match expression at match_heuristic.ml[13:15 ..13:22]")
         end
       end
+    else
+      if et.__tag == "Nil" then
+        if 2 == eu then
+          return 2
+        else
+          return error("Pattern matching failure in match expression at match_heuristic.ml[13:15 ..13:22]")
+        end
+      elseif et.__tag == "Cons" then
+        return 3
+      end
     end
-  })
+  end
+  local bottom = nil
+  bottom({ common_prefix = common_prefix, common_suffix = common_suffix, mixed_1 = mixed_1 })
 end

--- a/tests/lua/opt_inline_tyapp.lua
+++ b/tests/lua/opt_inline_tyapp.lua
@@ -1,0 +1,5 @@
+do
+  local __builtin_unit = { __tag = "__builtin_unit" }
+  local bottom = nil
+  bottom({ _1 = __builtin_unit, _2 = __builtin_unit })
+end

--- a/tests/lua/opt_inline_tyapp.ml
+++ b/tests/lua/opt_inline_tyapp.ml
@@ -1,0 +1,15 @@
+(* The conditions where this optimisation will trigger are currently
+   rather small, so we create a rather artificial test case here
+
+    - The definition must be used multiple times (otherwise pre-inline
+      unconditionally will kick in)
+
+    - The definition must be local (otherwise the inliner is not smart
+      enough to look through everything.
+*)
+
+external val bottom : 'a = "nil"
+let () =
+  let semigroup_unit = { append = fun _ () -> () }
+  bottom ( semigroup_unit.append () ()
+         , semigroup_unit.append () () )

--- a/tests/lua/optimise_sink.lua
+++ b/tests/lua/optimise_sink.lua
@@ -2,12 +2,13 @@ do
   local __builtin_unit = { __tag = "__builtin_unit" }
   local Nil = { __tag = "Nil" }
   local function Cons(x) return { __tag = "Cons", x } end
-  local bottom = nil
-  bottom(function(x)
+  local function main(x)
     if x.__tag == "Nil" then
       return function(dn) return { _1 = 1, _2 = x } end
     elseif x.__tag == "Cons" then
       return function(x0) return { _1 = x0, _2 = Nil } end
     end
-  end)
+  end
+  local bottom = nil
+  bottom(main)
 end

--- a/tests/lua/precedence.lua
+++ b/tests/lua/precedence.lua
@@ -1,5 +1,6 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
-  bottom(function(bn) return (bn.a + bn.b) * bn.c end)
+  local function main(bn) return (bn.a + bn.b) * bn.c end
+  bottom(main)
 end


### PR DESCRIPTION
 - Keep track of the "usage context" for deferred applications.
 - Try to be a little smarter about when we inline:
   - Always inline when the definition is smaller than the application itself
   - Never inline if all arguments are unknown, and the function isn't used anywhere interesting.
   - Otherwise compare the body size minus some discounts to the threshold. Here the discounts are "Known argument which is applied/matched on" and "known result which is applied/matched on".

We need to do a lot of fine-tuning of the heurstic and definition scores to ensure this is actually effective. There's definitely some values here which are rather off.

As always, [largely based on this paper](https://www.microsoft.com/en-us/research/wp-content/uploads/2002/07/inline.pdf).