### PR TITLE
Some more inliner love

### DIFF
--- a/tests/lua/stream-zip.lua
+++ b/tests/lua/stream-zip.lua
@@ -1,0 +1,87 @@
+do
+  local __builtin_unit = { __tag = "__builtin_unit" }
+  local print = print
+  local to_string = tostring
+  local function Skip(x) return { __tag = "Skip", x } end
+  local function Yield(x) return { __tag = "Yield", x } end
+  local Done = { __tag = "Done" }
+  local function Stream(x) return { __tag = "Stream", x } end
+  local function Some(x) return { __tag = "Some", x } end
+  local None = { __tag = "None" }
+  local function zip(bat)
+    local bav = bat[1]
+    local f = bav._1
+    local start = bav._2
+    return function(ban)
+      local bap = ban[1]
+      local g = bap._1
+      return Stream({
+        _1 = function(baz)
+          local bab = baz._2
+          local sb = bab._1
+          local x = bab._2
+          local sa = baz._1
+          if x.__tag == "Some" then
+            local x0 = x[1]
+            local bac = g(sb)
+            if bac.__tag == "Skip" then
+              return Skip({ _1 = sa, _2 = { _1 = bac[1], _2 = Some(x0) } })
+            elseif bac.__tag == "Yield" then
+              local bat0 = bac[1]
+              return Yield({
+                _1 = { _1 = x0, _2 = bat0._1 },
+                _2 = { _1 = sa, _2 = { _1 = bat0._2, _2 = None } }
+              })
+            elseif bac.__tag == "Done" then
+              return Done
+            end
+          elseif x.__tag == "None" then
+            local ayj = f(sa)
+            if ayj.__tag == "Skip" then
+              return Skip({ _1 = ayj[1], _2 = { _1 = sb, _2 = None } })
+            elseif ayj.__tag == "Yield" then
+              local ayy = ayj[1]
+              return Skip({ _1 = ayy._2, _2 = { _1 = sb, _2 = Some(ayy._1) } })
+            elseif ayj.__tag == "Done" then
+              return Done
+            end
+          end
+        end,
+        _2 = { _1 = start, _2 = { _1 = bap._2, _2 = None } }
+      })
+    end
+  end
+  local avc = zip(Stream({
+    _1 = function(n)
+      if n > 100 then
+        return Done
+      else
+        return Yield({ _1 = n, _2 = n + 1 })
+      end
+    end,
+    _2 = 1
+  }))(Stream({
+    _1 = function(n)
+      if n > 300 then
+        return Done
+      else
+        return Yield({ _1 = n, _2 = n + 1 })
+      end
+    end,
+    _2 = 100
+  }))[1]
+  local go = avc._1
+  local function go0(bmf_1, bmf_2)
+    local auj = go(bmf_2)
+    if auj.__tag == "Skip" then
+      return go0(bmf_1, auj[1])
+    elseif auj.__tag == "Yield" then
+      local aut = auj[1]
+      local x = aut._1
+      return go0(x._1 + x._2 + bmf_1, aut._2)
+    elseif auj.__tag == "Done" then
+      return bmf_1
+    end
+  end
+  print(to_string(go0(0, avc._2)))
+end

--- a/tests/lua/stream-zip.ml
+++ b/tests/lua/stream-zip.ml
@@ -1,0 +1,104 @@
+external val io_write : string -> unit = "io.write"
+external val print : string -> unit = "print"
+external val to_string : 'a -> string = "tostring"
+external val rem : int -> int -> int = "function(x, y) return x % y end"
+
+type step 's 'a =
+  | Skip of 's
+  | Yield of 'a * 's
+  | Done
+
+type stream 'a =
+  | Stream : forall 's. ('s -> step 's 'a) * 's -> stream 'a
+
+type option 'a = Some of 'a | None
+
+let take len (Stream (f, start)) =
+  let go (i, st) =
+    if i <= len then
+      match f st with
+      | Done -> Done
+      | Skip s -> Skip (i + 1, s)
+      | Yield (a, s) -> Yield (a, i + 1, s)
+    else
+      Done
+  Stream (go, 1, start)
+
+let map f (Stream (go, start)) =
+  let loop st =
+    match go st with
+    | Done -> Done
+    | Skip s -> Skip s
+    | Yield (x, s) -> Yield (f x, s)
+  Stream (loop, start)
+
+let filter p (Stream (f, start)) =
+  let go st =
+    match f st with
+    | Done -> Done
+    | Skip s -> Skip s
+    | Yield (a, s) ->
+      if p a then
+        Yield (a, s)
+      else
+        Skip s
+  Stream (go, start)
+
+let range (start, limit) =
+  let go n =
+    if n > limit then
+      Done
+    else
+      Yield (n, n + 1)
+  Stream (go, start)
+
+let fold_stream f z (Stream (stream, start)) =
+  let go ac st =
+    match stream st with
+    | Yield (a, st) -> go (f a ac) st
+    | Skip st -> go ac st
+    | Done -> ac
+  go z start
+
+let dump_stream e (Stream (f, start)) =
+  let go st =
+    match f st with
+    | Skip st -> go st
+    | Yield (a, st) -> begin
+      io_write ("'" ^ e a ^ "', ");
+      go st
+    end
+    | Done -> print "]"
+  io_write "[";
+  go start
+
+let zip (Stream (f, start)) (Stream (g, start')) =
+  let go (sa, sb, x) =
+    match x with
+    | None ->
+        match f sa with
+        | Done -> Done
+        | Skip sa' -> Skip (sa', sb, None)
+        | Yield (x, sa') -> Skip (sa', sb, Some x)
+    | Some x ->
+        match g sb with
+        | Done -> Done
+        | Skip sb' -> Skip (sa, sb', Some x)
+        | Yield (y, sb') -> Yield ((x, y), sa, sb', None)
+  Stream (go, start, start', None)
+
+let (|>) x f = f x
+let uncurry f (x, y) = f x y
+
+let (>>>) f g = fun x -> g (f x)
+
+let sum_squares xs =
+  xs |> map (fun x -> x * x) |> fold_stream (+) 0
+
+let () =
+  zip (range (1, 100)) (range (100, 300))
+        |> map (uncurry (+))
+        |> fold_stream (+) 0
+        |> to_string
+        |> print
+


### PR DESCRIPTION
Just a couple of improvements I'd like to make to the inliner and various optimisations

 - [x] Eliminate matches before determining if something is suitable for inlining.
 - [ ] Improve node costs for `scoreTerm`/`scoreAtom`, and discounts for applications and whatnot, so we don't inline large but trivial functions, and we do inline small but "worth it" ones.
 - [ ] Allow the uncurrying pass to either move matches on arguments into the a child lambda (problematic as it duplicates work) or unbox them directly.


The last of these is needed as `zip` gets translated into:
```ml
let zip = fun x ->
  match x with
  | Stream (f, start) -> fun y -> match y with
                       | Stream (g, start') -> (* The interesting stuff *)
```
Even after optimisation, we still have a match between the two lambdas, so we need to avoid that some how. It's worth noting that shifting the `match`es` further in does allow the unboxing to occur, but is not sufficient to get it to fully inline.