### PR TITLE
REPL file loading

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -23,6 +23,7 @@ executable amc
                      , amulet
                      , haskeline >= 0.7 && < 0.8
                      , containers >= 0.5 && < 0.6
+                     , optparse-applicative >= 0.14 && < 0.15
                      , pretty-show
 
   other-modules:       Repl

--- a/compiler/Debug.hs
+++ b/compiler/Debug.hs
@@ -18,7 +18,7 @@ import Backend.Lua
 import Text.Pretty.Semantic
 
 data DebugMode = Void | Test | TestTc
-  deriving Eq
+  deriving (Show, Eq)
 
 dump :: DebugMode
      -> [Toplevel Typed]

--- a/default.nix
+++ b/default.nix
@@ -61,6 +61,7 @@ let
       , template-haskell
       , annotated-wl-pprint
       , unordered-containers
+      , optparse-applicative
       , tasty-hedgehog
       }:
       let alex' = haskell.lib.dontCheck alex;
@@ -82,7 +83,7 @@ let
 
         executableHaskellDepends = [
           mtl text base lens bytestring containers pretty-show hslua
-          haskeline
+          haskeline optparse-applicative
         ];
 
         testHaskellDepends = [


### PR DESCRIPTION
 - [x] Allow using `:l` (and `:load`) to load a file into the REPL.
 - [x] Add `:r` to reload already loaded files.

I'd like to add support for reloading files before finishing this off, but there's a coupel of questions worth resolving:

 - Should using `:load` reset the environment. This is useful, as there won't be artifacts from previous `:load`s.
 - If we do reset the environment, how does one load multiple files? One possibility would be to specify multiple files to `:load`. Obviously the whole module resolution thing is a whole 'nother discussion, but...
 - How should `:reload` handle file order (if we don't have variadic load)?