### PR TITLE
Default Methods

### DIFF
--- a/examples/amulet-logo.ml
+++ b/examples/amulet-logo.ml
@@ -101,7 +101,7 @@ let () =
 
   (* Some helper functions and values *)
   let angle = 360.0 /. float_of_int points
-  let angle_at (point : int) : float = rot_offset +. angle *. float_of_int point
+  let angle_at point = rot_offset +. angle *. float_of_int point
   let point_at r offset theta =
     angle_at theta |> (+.offset) |> Math.rad
     |> Math.polar r

--- a/src/Data/Reason.hs
+++ b/src/Data/Reason.hs
@@ -81,8 +81,9 @@ instance (Spanned (Ann p), Pretty (Var p)) => Reasonable Binding p where
 instance (Pretty (Var p), Reasonable Pattern p, Reasonable Expr p) => Reasonable Arm p where
   blame _ = string "the pattern-matching clause"
 
-instance (Spanned (Ann p), Pretty (Var p)) => Reasonable MethodSig p where
-  blame _ = string "the" <+> highlight "method signature"
+instance (Spanned (Ann p), Pretty (Var p)) => Reasonable ClassItem p where
+  blame MethodSig{} = string "the" <+> highlight "method signature"
+  blame DefaultMethod{} = string "the" <+> highlight "default method"
 
 instance Reasonable (Const SomeReason) p where
   blame = blameOf . getConst

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -158,8 +158,8 @@ Top :: { Toplevel Parsed }
     | module conid '=' '$begin' Tops '$end'    { Module (getName $2) $5 }
     | module conid '=' Con                     { Open (getL $4) (Just (getIdent $2)) }
 
-    | class Type begin MethodSigs end          {% fmap (withPos2 $1 $5) $ buildClass $2 $4 }
-    | class Type '$begin' MethodSigs '$end'    {% fmap (withPos2 $1 $5) $ buildClass $2 $4 }
+    | class Type begin ClassItems end          {% fmap (withPos2 $1 $5) $ buildClass $2 $4 }
+    | class Type '$begin' ClassItems '$end'    {% fmap (withPos2 $1 $5) $ buildClass $2 $4 }
 
     | instance Type begin Methods end          {% fmap (withPos2 $1 $5) $ buildInstance $2 $4 }
     | instance Type '$begin' Methods '$end'    {% fmap (withPos2 $1 $5) $ buildInstance $2 $4 }
@@ -168,11 +168,12 @@ Top :: { Toplevel Parsed }
 --  | Instance                                 { $1 }
     | open Con                                 { Open (getL $2) Nothing }
 
-MethodSigs :: { [MethodSig Parsed] }
-  : List(MethodSig, TopSep) { $1 }
+ClassItems :: { [ClassItem Parsed] }
+  : List(ClassItem, TopSep) { $1 }
 
-MethodSig :: { MethodSig Parsed }
+ClassItem :: { ClassItem Parsed }
   : val BindName ':' Type { withPos2 $1 $4 $ MethodSig (getL $2) (getL $4) }
+  | let Binding { withPos2 $1 $2 $ DefaultMethod $2 }
 
 Methods :: { [Binding Parsed] }
   : List(Method, TopSep) { $1 }
@@ -527,7 +528,7 @@ respanFun :: (Spanned a, Spanned b) => a -> b -> Expr Parsed -> Expr Parsed
 respanFun s e (Fun p b _) = Fun p b (mkSpanUnsafe (spanStart (annotation s)) (spanEnd (annotation e)))
 respanFun _ _ _ = error "what"
 
-buildClass :: Located (Type Parsed) -> [MethodSig Parsed]
+buildClass :: Located (Type Parsed) -> [ClassItem Parsed]
            -> Parser (Span -> Toplevel Parsed)
 buildClass (L parsed typ) ms =
   case parsed of

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -273,7 +273,7 @@ data Toplevel p
   | Class { className :: Var p
           , classCtx :: Maybe (Type p)
           , classParams :: [TyConArg p]
-          , classMethods :: [MethodSig p]
+          , classMethods :: [ClassItem p]
           , ann :: Ann p }
   | Instance { instanceClass :: Var p
              , instanceCtx :: Maybe (Type p)
@@ -286,16 +286,19 @@ deriving instance (Show (Var p), Show (Ann p)) => Show (Toplevel p)
 deriving instance (Ord (Var p), Ord (Ann p)) => Ord (Toplevel p)
 deriving instance (Data p, Typeable p, Data (Var p), Data (Ann p)) => Data (Toplevel p)
 
-data MethodSig p =
-  MethodSig { _methName :: Var p
-            , _methTy :: Type p
-            , _methAnn :: Ann p
-            }
+data ClassItem p
+  = MethodSig { _methName :: Var p
+              , _methTy :: Type p
+              , _methAnn :: Ann p
+              }
+  | DefaultMethod { _methodBinding :: Binding p
+                  , _methAnn :: Ann p
+                  }
 
-deriving instance (Eq (Var p), Eq (Ann p)) => Eq (MethodSig p)
-deriving instance (Show (Var p), Show (Ann p)) => Show (MethodSig p)
-deriving instance (Ord (Var p), Ord (Ann p)) => Ord (MethodSig p)
-deriving instance (Data p, Typeable p, Data (Var p), Data (Ann p)) => Data (MethodSig p)
+deriving instance (Eq (Var p), Eq (Ann p)) => Eq (ClassItem p)
+deriving instance (Show (Var p), Show (Ann p)) => Show (ClassItem p)
+deriving instance (Ord (Var p), Ord (Ann p)) => Ord (ClassItem p)
+deriving instance (Data p, Typeable p, Data (Var p), Data (Ann p)) => Data (ClassItem p)
 
 data TyConArg p
   = TyVarArg (Var p)
@@ -350,7 +353,7 @@ makeLenses ''Skolem
 makeLenses ''TyBinder
 makeLenses ''Binding
 makeLenses ''Parameter
-makeLenses ''MethodSig
+makeLenses ''ClassItem
 
 instance Spanned (Ann p) => Spanned (Binding p) where
   annotation = annotation . _bindAnn
@@ -413,7 +416,7 @@ instance Spanned (Ann p) => Spanned (Expr p) where
 instance (Data (Ann p), Data (Var p), Data p) => Spanned (Parameter p) where
   annotation = annotation . view paramPat
 
-instance Spanned (Ann p) => Spanned (MethodSig p) where
+instance Spanned (Ann p) => Spanned (ClassItem p) where
   annotation = annotation . view methAnn
 
 {- Note [1]: Tuple types vs tuple patterns/values

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -145,7 +145,7 @@ instance Pretty (Var p) => Pretty (Binding p) where
   pretty (Matching p e _) = pretty p <+> nest 2 (equals </> pretty e)
   pretty (TypedMatching p e _ _) = pretty p <+> equals <+> pretty e
 
-instance Pretty (Var p) => Pretty (MethodSig p) where
+instance Pretty (Var p) => Pretty (ClassItem p) where
   pretty (MethodSig v t _) = keyword "val" <+> pretty v <+> colon <+> pretty t
 
 instance (Pretty (Var p)) => Pretty (Type p) where

--- a/src/Syntax/Pretty.hs
+++ b/src/Syntax/Pretty.hs
@@ -147,6 +147,7 @@ instance Pretty (Var p) => Pretty (Binding p) where
 
 instance Pretty (Var p) => Pretty (ClassItem p) where
   pretty (MethodSig v t _) = keyword "val" <+> pretty v <+> colon <+> pretty t
+  pretty (DefaultMethod b _) = keyword "let" <+> pretty b
 
 instance (Pretty (Var p)) => Pretty (Type p) where
   pretty (TyCon v) = stypeCon (pretty v)
@@ -158,7 +159,7 @@ instance (Pretty (Var p)) => Pretty (Type p) where
   pretty (TyWildcard (Just t)) = soperator (string "'_") <> pretty t
   pretty TyWildcard{} = skeyword (char '_')
 
-  pretty (TyRows p rows) = enclose (lbrace <> space) (space <> rbrace)  $ pretty p <+> soperator pipe <+> hsep (punctuate comma (prettyRows colon rows)) 
+  pretty (TyRows p rows) = enclose (lbrace <> space) (space <> rbrace)  $ pretty p <+> soperator pipe <+> hsep (punctuate comma (prettyRows colon rows))
   pretty (TyExactRows rows) = record (prettyRows colon rows)
 
   pretty (TyApp x e) = pretty x <+> parenTyArg e (pretty e) where

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -168,7 +168,7 @@ resolveModule (t@(Class name ctx tvs ms ann):rs) = do
       name' <- tagVar name
       pure ( MethodSig name' <$> reType m ty <*> pure an
            , [(name, name')] )
-    reClassItem (DefaultMethod b an) = do
+    reClassItem (DefaultMethod b an) =
       pure ( DefaultMethod <$> (fst =<< reMethod b) <*> pure an
            , [] )
 

--- a/src/Syntax/Resolve/Toplevel.hs
+++ b/src/Syntax/Resolve/Toplevel.hs
@@ -27,7 +27,9 @@ extractToplevel (TypeDecl v _ c) = (map ctor c, [v]) where
 extractToplevel (Open _ _) = ([], [])
 extractToplevel (Module v xs) = let (vs, ts) = extractToplevels xs
                                 in (map (v<>) vs, map (v<>) ts)
-extractToplevel (Class v _ _ ms _) = (v:map _methName ms, [])
+extractToplevel (Class v _ _ ms _) = (v:foldMap getName ms, []) where
+  getName (MethodSig v _ _) = [v]
+  getName (DefaultMethod b _) = bindVariables b
 extractToplevel Instance{} = ([], [])
 
 -- | Extract all top-level variables declared within a series of

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -8,7 +8,7 @@ module Syntax.Types
   , Env, freeInEnv, difference, envOf, scopeFromList, toMap
   , names, typeVars, constructors, letBound, classes, modules
   , classDecs
-  , ClassInfo(..), ciName, ciMethods, ciContext, ciConstructorName, ciConstructorTy, ciHead, ciClassSpan
+  , ClassInfo(..), ciName, ciMethods, ciContext, ciConstructorName, ciConstructorTy, ciHead, ciClassSpan, ciDefaults
   , Origin(..)
 
   , focus
@@ -95,6 +95,9 @@ data ClassInfo =
     , _ciConstructorTy :: Type Typed
       -- ^ The type of the constructor for this class
     , _ciClassSpan :: Ann Resolved
+      -- ^ The annotation of the class
+    , _ciDefaults :: Map.Map Text (Expr Resolved)
+      -- ^ Default methods
     }
   deriving (Eq, Show, Ord)
 

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -8,6 +8,7 @@ module Syntax.Types
   , Env, freeInEnv, difference, envOf, scopeFromList, toMap
   , names, typeVars, constructors, letBound, classes, modules
   , classDecs
+  , ClassInfo(..), ciName, ciMethods, ciContext, ciConstructorName, ciConstructorTy, ciHead, ciClassSpan
   , Origin(..)
 
   , focus
@@ -16,6 +17,7 @@ module Syntax.Types
 
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
+import Data.Text (Text)
 
 import Control.Arrow
 import Control.Lens
@@ -74,11 +76,30 @@ data Env
         , _constructors :: Set.Set (Var Typed)
         , _letBound     :: Set.Set (Var Typed)
         , _modules      :: Map.Map (Var Typed) (ImplicitScope Typed)
-        , _classDecs    :: Map.Map (Var Typed) (Toplevel Typed)
+        , _classDecs    :: Map.Map (Var Typed) ClassInfo
         }
   deriving (Eq, Show, Ord)
 
+data ClassInfo =
+  ClassInfo
+    { _ciName :: Var Typed
+      -- ^ The name of this class
+    , _ciHead :: Type Typed
+      -- ^ The head of this class (name applied to parameters)
+    , _ciMethods :: Map.Map (Var Typed) (Type Typed)
+      -- ^ A map of methods to their signatures
+    , _ciContext :: Map.Map Text (Type Typed)
+      -- ^ The superclasses of this class, 
+    , _ciConstructorName :: Var Typed
+      -- ^ The name of the constructor for this class
+    , _ciConstructorTy :: Type Typed
+      -- ^ The type of the constructor for this class
+    , _ciClassSpan :: Ann Resolved
+    }
+  deriving (Eq, Show, Ord)
+
 makeLenses ''Env
+makeLenses ''ClassInfo
 
 (\\) :: Ord (Var p) => Scope p f -> Scope p f -> Scope p f
 Scope x \\ Scope y = Scope (x Map.\\ y)

--- a/src/Types/Kinds.hs
+++ b/src/Types/Kinds.hs
@@ -96,11 +96,13 @@ resolveClassKind stmt@(Class classcon ctx args methods _) = do
     let scope = one classcon kind <> tele
     local (names %~ focus scope) $ do
       traverse_ (`checkKind` tyConstraint) ctx
-      for_ methods $ \m@(MethodSig _ ty _) -> do
-        put (BecauseOf m)
-        retcons (addBlame (BecauseOf m)) $
-          checkKind ty TyType
-        <* put reason
+      for_ methods $ \case
+        m@(MethodSig _ ty _) -> do
+          put (BecauseOf m)
+          _ <- retcons (addBlame (BecauseOf m)) $
+            checkKind ty TyType
+          put reason
+        _ -> pure ()
     pure kind
   let remake (TyVarArg v:as) (TyArr k r) = TyAnnArg (TvName v) k:remake as r
       remake (TyAnnArg v _:as) (TyArr k r) = TyAnnArg (TvName v) k:remake as r

--- a/tests/lua/default-method.lua
+++ b/tests/lua/default-method.lua
@@ -1,0 +1,15 @@
+do
+  local __builtin_unit = { __tag = "__builtin_unit" }
+  local function _dollarlShowcj(fm)
+    return {
+      show = function(fi) return "()" end,
+      show_tail = function(x) return "tail" .. _dollarlShowcj(__builtin_unit).show(x) end
+    }
+  end
+  local fs = _dollarlShowcj(__builtin_unit).show_tail(__builtin_unit)
+  if fs == "" then
+
+  else
+    error("Pattern matching failure in let expression at default-method.ml[12:5 ..12:6]")
+  end
+end

--- a/tests/lua/default-method.ml
+++ b/tests/lua/default-method.ml
@@ -1,0 +1,12 @@
+class show 'a begin
+  val show : 'a -> string
+  val show_tail : 'a -> string
+
+  let show_tail x = "tail" ^ show x
+end
+
+instance show () begin
+  let show () = "()"
+end
+
+let "" = show_tail ()

--- a/tests/lua/monoid.lua
+++ b/tests/lua/monoid.lua
@@ -4,8 +4,8 @@ do
   local writeln = print
   local function _dollardApplicativeafh(aha)
     return {
-      pure = function(ccg) return aha.zero end,
       ["<*>"] = function(cbz) return function(cbw) return aha["×"](cbz)(cbw) end end,
+      pure = function(ccg) return aha.zero end,
       ["Applicative$kp"] = function(cbl) return function(cbi) return cbi end end
     }
   end
@@ -39,6 +39,7 @@ do
   end
   local function _dollarlMonoidbne(cin)
     return {
+      zero = Nil,
       ["×"] = function(x)
         return function(ys)
           if x.__tag == "Cons" then
@@ -48,8 +49,7 @@ do
             return ys
           end
         end
-      end,
-      zero = Nil
+      end
     }
   end
   local cjp = { _1 = 1, _2 = __builtin_unit }

--- a/tests/parser/pass_class.ml
+++ b/tests/parser/pass_class.ml
@@ -19,3 +19,9 @@ instance multiline string
 
 class multi 'a 'b 'c
 instance multi int string () begin end
+
+class default 'a
+  val a : 'a
+  val b : 'a
+
+  let a = b

--- a/tests/parser/pass_class.out
+++ b/tests/parser/pass_class.out
@@ -23,3 +23,8 @@ end
 instance () => multi int string unit begin
   
 end
+class () => default a begin
+  val a : 'a
+  val b : 'a
+  let a = b
+end

--- a/tests/resolve/pass_class.ml
+++ b/tests/resolve/pass_class.ml
@@ -3,3 +3,9 @@ class semigroup 'a
 
 instance semigroup int
   let (<>) = (+)
+
+class default 'a
+  val a : 'a
+  val b : 'a
+
+  let a = b

--- a/tests/resolve/pass_class.out
+++ b/tests/resolve/pass_class.out
@@ -4,3 +4,8 @@ end
 instance () => semigroup#0 int begin
   <>#2 = ((+))
 end
+class () => default#3 a#4 begin
+  val a#5 : 'a#4
+  val b#6 : 'a#4
+  let a#5 = b#6
+end

--- a/tests/types/class/default01.ml
+++ b/tests/types/class/default01.ml
@@ -1,0 +1,22 @@
+class eq 'a begin
+  val eq : 'a -> 'a -> bool
+end
+
+instance eq () begin
+  let eq () () = true
+end
+
+class eq 'a => show 'a begin
+  val show : 'a -> string
+  val show_tail : 'a -> string
+
+  let show_tail x =
+    if x `eq` x then
+      ""
+    else
+      ""
+end
+
+instance show () begin
+  let show () = "()"
+end

--- a/tests/types/class/default01.out
+++ b/tests/types/class/default01.out
@@ -1,0 +1,5 @@
+eq : type -> constraint
+eq : {'a : type}. eq 'a => 'a -> 'a -> bool
+show : type -> constraint
+show : {'a : type}. show 'a => 'a -> string
+show_tail : {'a : type}. show 'a => 'a -> string

--- a/tests/types/class/default02-fail.ml
+++ b/tests/types/class/default02-fail.ml
@@ -1,0 +1,22 @@
+class eq 'a begin
+  val eq : 'a -> 'a -> bool
+end
+
+instance eq () begin
+  let eq () () = true
+end
+
+class show 'a begin
+  val show : 'a -> string
+  val show_tail : 'a -> string
+
+  let show_tail x =
+    if x `eq` x then
+      ""
+    else
+      ""
+end
+
+instance show () begin
+  let show () = "()"
+end

--- a/tests/types/class/default02-fail.out
+++ b/tests/types/class/default02-fail.out
@@ -1,0 +1,12 @@
+default02-fail.ml[14:8 ..14:15]: error
+  No instance for eq 'a when checking that show_tail
+  is an implementation for type
+    forall 'a. show 'a => 'a -> string
+
+  • Note: default method implementations should always be applicable,
+    and thus can not have any extra constraints
+
+  Arising in the the expression
+   │ 
+14 │     if x `eq` x then
+   │        ^^^^^^^^

--- a/tests/types/class/default03.ml
+++ b/tests/types/class/default03.ml
@@ -1,0 +1,9 @@
+class foo 'a begin
+  val x : 'a -> int
+  val y : 'a -> int
+  let y _ = 0
+end
+
+instance foo int begin
+  let x _ = 0
+end

--- a/tests/types/class/default03.out
+++ b/tests/types/class/default03.out
@@ -1,0 +1,3 @@
+foo : type -> constraint
+x : {'a : type}. foo 'a => 'a -> int
+y : {'a : type}. foo 'a => 'a -> int


### PR DESCRIPTION
Pretty self-explanatory: Default implementations for a method in the body of the class itself.

For _instance_ (ba dum tss):
```ocaml
class eq 'a begin
  val (==) : 'a -> 'a -> bool
  val (<>) : 'a -> 'a -> bool

  let x <> y = not (x == y)
  let x == y = not (x <> y)
end
```

This class can be implemented by either implementing...
 - both `(==)` and `(<>)`, or
 - just `(==)`, or
 - just `(<>)`.