### PR TITLE
Convert Var to a type family rather than data family

### DIFF
--- a/compiler/Repl.hs
+++ b/compiler/Repl.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, FlexibleContexts, ScopedTypeVariables, ViewPatterns #-}
+{-# LANGUAGE OverloadedStrings, FlexibleContexts, ScopedTypeVariables, ViewPatterns, TypeFamilies #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Repl

--- a/compiler/Test/Syntax/Gen.hs
+++ b/compiler/Test/Syntax/Gen.hs
@@ -33,7 +33,7 @@ genType =
     , TyApp <$> genType <*> genType
     , do
         v <- genVar
-        TyForall (TvName v) . Just <$> genType <*> genType
+        TyForall v . Just <$> genType <*> genType
     , do
         n <- Gen.int (Range.linear 1 10)
         let alpha = map singleton $ cycle ['a'..'z']

--- a/compiler/Test/Types/Util.hs
+++ b/compiler/Test/Types/Util.hs
@@ -46,7 +46,7 @@ checkExpr e t = flip Namey.evalNamey MonadInfer.firstName $ MonadInfer.runInfer 
 
 equivalent, disjoint :: Type Typed -> Type Typed -> Bool
 equivalent a b =
-  let task = Seq.singleton (ConUnify (BecauseOf (Blame internal)) (TvName (TgInternal "co")) a b)
+  let task = Seq.singleton (ConUnify (BecauseOf (Blame internal)) (TgInternal "co") a b)
   in case flip Namey.evalNamey MonadInfer.firstName . MonadInfer.runChronicleT . solve $ task of
     That{} -> True
     _ -> False
@@ -55,11 +55,11 @@ disjoint a b = not (a `equivalent` b)
 
 unify :: Type Typed -> Type Typed -> Either (Seq TypeError) (Coercion Typed)
 unify a b =
-  let task = Seq.singleton (ConUnify (BecauseOf (Blame internal)) (TvName (TgInternal "co")) a b)
+  let task = Seq.singleton (ConUnify (BecauseOf (Blame internal)) (TgInternal "co") a b)
   in case flip Namey.evalNamey MonadInfer.firstName . MonadInfer.runChronicleT . solve $ task of
     This e -> Left e
     These e _ -> Left e
-    That (_, m, _) -> case m Map.! TvName (TgInternal "co") of
+    That (_, m, _) -> case m Map.! TgInternal "co" of
       Cast co -> Right co
       IdWrap -> Right (AssumedCo a b)
       c -> error ("not a coercion " ++ show c)

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -222,7 +222,7 @@ instantiate r tp@(TyPi (Anon co) od@dm) = do
       lam e | od == dm = e
       lam e
         | ann <- annotation e
-        = Fun (PatParam (PType (Capture (TvName var) (ann, co)) co (ann, co))) (cont (App e (VarRef (TvName var) (ann, co)) (ann, od))) (ann, ty)
+        = Fun (PatParam (PType (Capture var (ann, co)) co (ann, co))) (cont (App e (VarRef var (ann, co)) (ann, od))) (ann, ty)
 
   pure (Just lam, tp, ty)
 
@@ -235,16 +235,16 @@ instantiate r tp@(TyPi (Implicit co) od@dm) = do
       lam e | od == dm = e
       lam e
         | ann <- annotation e
-        = Fun (EvParam (PType (Capture (TvName var) (ann, co)) co (ann, co))) (cont (App e (VarRef (TvName var) (ann, co)) (ann, od))) (ann, ty)
+        = Fun (EvParam (PType (Capture var (ann, co)) co (ann, co))) (cont (App e (VarRef var (ann, co)) (ann, od))) (ann, ty)
 
   pure (Just lam, tp, ty)
 instantiate _ ty = pure (Just id, ty, ty)
 
 freshTV :: MonadNamey m => m (Type Typed)
-freshTV = TyVar . TvName <$> genName
+freshTV = TyVar <$> genName
 
 refreshTV :: MonadNamey m => Var Typed -> m (Type Typed)
-refreshTV (TvName v) = TyVar . TvName <$> genNameFrom nm where
+refreshTV v = TyVar <$> genNameFrom nm where
   nm = case v of
     TgInternal x -> x
     TgName x _ -> x

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -333,9 +333,6 @@ pattern TyForall :: Var p -> Maybe (Type p) -> Type p -> Type p
 pattern TyForall v k t' <- TyPi (Invisible v k) t' where
   TyForall v k ty = TyPi (Invisible v k) ty
 
-unTvName :: Var Typed -> Var Resolved
-unTvName (TvName x) = x
-
 getType :: Data (f Typed) => f Typed -> Type Typed
 getType = snd . head . catMaybes . gmapQ get where
   get d = fmap (`asTypeOf` (undefined :: (Span, Type Typed))) (cast d)

--- a/src/Syntax/Verify.hs
+++ b/src/Syntax/Verify.hs
@@ -251,7 +251,7 @@ unguardedVars (Let vs b _)         = (unguardedVars b <> foldMap (unguardedVars 
                               Set.\\ foldMapOf (each . bindVariable) Set.singleton vs
 unguardedVars (App f x _) =
   case f of
-    ExprWrapper _ (VarRef (TvName (TgInternal "force")) _) _ -> freeIn f <> freeIn x
+    ExprWrapper _ (VarRef (TgInternal "force") _) _ -> freeIn f <> freeIn x
     _ -> freeIn f <> unguardedVars x
 unguardedVars Fun{}                = mempty
 unguardedVars (Record rs _)        = foldMap (unguardedVars . view fExpr) rs

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -443,7 +443,7 @@ inferLetTy closeOver strategy vs =
 
         vt <- closeOver (Set.singleton (fst blame))
                 ex (apply x (context ty))
-        ty <- skolCheck (fst blame) (snd blame) vt
+        ty <- uncurry skolCheck blame vt
         let (tp, sub) = rename ty
 
         pure (tp, wrapper Full . solve tp sub . substituteDeferredDicts reify deferred)

--- a/src/Types/Infer/Outline.hs
+++ b/src/Types/Infer/Outline.hs
@@ -49,7 +49,7 @@ approximate :: MonadInfer Typed m
 approximate (Binding v e _) = do
   (ty, st) <- runStateT (approxType e) Supplied
   ty' <- generalise nominalTvs (becauseExp e) ty
-  pure (st, (TvName v, if not (wasGuessed st) then ty' else ty))
+  pure (st, (v, if not (wasGuessed st) then ty' else ty))
 approximate Matching{} = error "Matching before TC"
 approximate TypedMatching{} = error "TypedBinding before TC"
 


### PR DESCRIPTION
This allows us to add additional phrases between resolving and lowering without having to wrap the variable each time.