### PR TITLE
 Remove the MonadFail constraint from MonadNamey

### DIFF
--- a/compiler/Test/Syntax/Resolve.hs
+++ b/compiler/Test/Syntax/Resolve.hs
@@ -19,12 +19,12 @@ import qualified Text.Pretty.Note as N
 import Text.Pretty.Semantic
 
 result :: String -> T.Text -> T.Text
-result file contents = fst . flip runNamey firstName $ do
-  let (Just parsed, _) = runParser file (L.fromStrict contents) parseTops
+result f c = fst . flip runNamey firstName $ do
+  let parsed = requireJust f c $ runParser f (L.fromStrict c) parseTops
   resolved <- resolveProgram RS.builtinScope RS.emptyModules parsed
   pure . displayPlainVerbose . either prettyErrs ((Right<$>) . pretty . fst) $ resolved
 
-  where prettyErrs = vsep . map (N.format (N.fileSpans [(file, contents)] N.defaultHighlight))
+  where prettyErrs = vsep . map (N.format (N.fileSpans [(f, c)] N.defaultHighlight))
 
 tests :: IO TestTree
 tests = testGroup "Tests.Syntax.Resolve" <$> goldenDir result "tests/resolve/" ".ml"

--- a/compiler/Test/Util.hs
+++ b/compiler/Test/Util.hs
@@ -4,6 +4,10 @@ module Test.Util
   , displayPlainVerbose
   , hedgehog
   , module Test.Golden
+
+  , requireJust, requireRight, requireThat, requireThese
+
+  , toEither
   ) where
 
 import Hedgehog
@@ -14,6 +18,7 @@ import Test.Golden
 import Test.Tasty
 
 import qualified Data.Text as T
+import Data.These
 
 import qualified Text.Pretty.Note as N
 import Text.Pretty.Semantic
@@ -34,3 +39,31 @@ displayPlainVerbose
 hedgehog :: Group -> TestTree
 hedgehog Group { groupName = n, groupProperties = ps }
   = testGroup (unGroupName n) (map (\(n, p) -> testProperty (unPropertyName n) p) ps)
+
+requireJust :: N.Note a Style => String -> T.Text -> (Maybe b, [a]) -> b
+requireJust _ _ (Just x, _) = x
+requireJust f c (Nothing, es) = err f c es
+
+requireRight :: N.Note a Style  => String -> T.Text -> Either [a] b -> b
+requireRight _ _ (Right x) = x
+requireRight f c (Left es) = err f c es
+
+requireThat :: N.Note a Style => String -> T.Text -> These [a] b -> b
+requireThat _ _ (That x) = x
+requireThat _ _ (These [] x) = x
+requireThat f c (These es _) = err f c es
+requireThat f c (This es) = err f c es
+
+requireThese :: N.Note a Style => String -> T.Text -> These [a] b -> (b, [a])
+requireThese _ _ (That x) = (x, [])
+requireThese _ _ (These y x) = (x, y)
+requireThese f c (This es) = err f c es
+
+toEither :: These [a] b -> Either [a] b
+toEither (This e) = Left e
+toEither (These [] x) = Right x
+toEither (These e _) = Left e
+toEither (That x) = Right x
+
+err :: N.Note a Style => String -> T.Text -> [a] -> b
+err f c = error . T.unpack . displayPlain . vsep . map (N.format (N.fileSpans [(f, c)] N.defaultHighlight))

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -189,12 +189,12 @@ runInfer ct ac = over here toList <$>
 
 genNameFrom :: MonadNamey m => Text -> m (Var Desugared)
 genNameFrom t = do
-  TgName _ n <- genName
+  ~(TgName _ n) <- genName
   pure (TgName t n)
 
 genNameWith :: MonadNamey m => Text -> m (Var Desugared)
 genNameWith t = do
-  TgName e n <- genName
+  ~(TgName e n) <- genName
   pure (TgName (t <> e) n)
 
 firstName :: Var Desugared

--- a/src/Control/Monad/Namey.hs
+++ b/src/Control/Monad/Namey.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DerivingStrategies, GeneralizedNewtypeDeriving,
    FlexibleContexts, FlexibleInstances, MultiParamTypeClasses,
    UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
 
 {-| The compiler often needs a source of fresh variables, such as when
   performing optimisations or creating new type variables during
@@ -26,7 +25,6 @@ import qualified Control.Monad.Writer.Lazy as LazyW
 import qualified Control.Monad.State.Lazy as LazyS
 import qualified Control.Monad.RWS.Lazy as LazyRWS
 import qualified Control.Monad.Reader as Reader
-import qualified Control.Monad.Fail as Fail
 import Control.Monad.State.Class
 import Control.Monad.IO.Class
 import Control.Monad.Except
@@ -58,7 +56,6 @@ newtype NameyT m a =
   , StrictW.MonadWriter w
   , MonadError e
   , MonadIO
-  , Fail.MonadFail
   )
 
 -- | The namey monad
@@ -69,7 +66,7 @@ instance MonadState s m => MonadState s (NameyT m) where
   put = lift . StrictS.put
 
 -- | A source of fresh variable names
-class Fail.MonadFail m => MonadNamey m where
+class Monad m => MonadNamey m where
   -- | Get a fresh variable
   genName :: m Name
 
@@ -99,7 +96,7 @@ evalNamey :: NameyT Identity a -> Name -> a
 evalNamey (NameyT k) (TgName _ i) = StrictS.evalState k i
 evalNamey _ _ = undefined
 
-instance Fail.MonadFail m => MonadNamey (NameyT m) where
+instance Monad m => MonadNamey (NameyT m) where
   genName = NameyT $ do
     x <- get
     put (x + 1)
@@ -149,10 +146,3 @@ genAlnum n = go (fromIntegral n) T.empty (floor (logBase 26 (fromIntegral n :: D
               0 -> 1
               x -> x
      in go (n `mod'` (26 ^ p)) (T.snoc out (chr (96 + m))) (p - 1)
-
--- Ugh orphans:
-instance (Semigroup c, Fail.MonadFail m) => Fail.MonadFail (Chronicle.ChronicleT c m) where
-  fail x = lift $ Fail.fail x
-
-instance Fail.MonadFail Identity where
-  fail x = error $ "MonadFail identity: fail " ++ x

--- a/src/Core/Lower/Pattern.hs
+++ b/src/Core/Lower/Pattern.hs
@@ -452,9 +452,9 @@ lowerOneOf preLeafs var ty tys = go [] . map prepare
     goCtors unc cases (( S.Destructure v (Just p) (_, cty)
                        , PR arm pats gd vBind tyBind ):rs) = do
       let v' = mkCon v
-      (Just cap@(Capture c _), cases') <- case VarMap.lookup v' cases of
+      ~(Just cap@(Capture c _), cases') <- case VarMap.lookup v' cases of
         Nothing -> do
-          ForallTy Irrelevant x r <- inst . fromJust <$> asks (VarMap.lookup (mkType v) . ctors)
+          ~(ForallTy Irrelevant x r) <- inst . fromJust <$> asks (VarMap.lookup (mkType v) . ctors)
           let Just s = r `unify` lowerType cty
               ty' = substituteInType s x
           (,unc) . Just . flip Capture ty' <$> freshFromPat p

--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -260,7 +260,7 @@ freshFrom' x = fromVar <$> freshFrom (toVar x)
 -- | Create a fresh 'CoVar'
 fresh :: MonadNamey m => VarInfo -> m CoVar
 fresh k = do
-  TgName nam x <- genName
+  ~(TgName nam x) <- genName
   pure (CoVar x nam k)
 
 -- | Create a fresh variable

--- a/src/Core/Optimise/Newtype.hs
+++ b/src/Core/Optimise/Newtype.hs
@@ -30,7 +30,7 @@ killNewtypePass = go mempty mempty where
     xs' <- go ss m xs
     pure (StmtLet (Many vs'):xs')
   go ss m (StmtLet (One v):xs) = do
-    [v'] <- goBinding ss m [v]
+    ~[v'] <- goBinding ss m [v]
     xs' <- go ss m xs
     pure (StmtLet (One v'):xs')
 

--- a/src/Syntax/Desugar.hs
+++ b/src/Syntax/Desugar.hs
@@ -73,7 +73,7 @@ desugarProgram = traverse statement where
       VarRef{} -> pure $ go vl'
       Literal{} -> pure $ go vl'
       _ -> do
-        (Capture lv _, ref) <- fresh an
+        ~(Capture lv _, ref) <- fresh an
         pure $ Let [Binding lv vl' an] (go ref) an
 
   expr (RightSection vl op an) = expr (App op vl an)
@@ -111,7 +111,7 @@ desugarProgram = traverse statement where
   buildTuple _ (Just e@VarRef{}) (as, vs, tuple) = pure (as, vs, e:tuple)
   buildTuple _ (Just e@Literal{}) (as, vs, tuple) = pure (as, vs, e:tuple)
   buildTuple a (Just e) (as, vs, tuple) = do
-    (Capture v _, ref) <- fresh a
+    ~(Capture v _, ref) <- fresh a
     pure (as, (v, e):vs, ref:tuple)
 
   binding (Binding v e a) = Binding v <$> expr e <*> pure a

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -269,7 +269,7 @@ reExpr o@BinOp{} = do
       reOp es ops (BinOp l o@VarRef{} r _) = do
         (es', ops') <- reOp es ops l
 
-        o'@(VarRef op _) <- reExpr o
+        ~o'@(VarRef op _) <- reExpr o
         let (opre, oass) = precedenceOf precedence op
 
         let (es'', ops'') = popUntil es' ops' opre oass

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -211,8 +211,8 @@ infer ex@(Ascription e ty an) = do
 infer ex@(BinOp l o r a) = do
   (o, ty) <- infer o
 
-  (Anon lt, c1, k1) <- quantifier (becauseExp ex) ty
-  (Anon rt, c2, k2) <- quantifier (becauseExp ex) c1
+  ~(Anon lt, c1, k1) <- quantifier (becauseExp ex) ty
+  ~(Anon rt, c2, k2) <- quantifier (becauseExp ex) c1
 
   (l, r) <- (,) <$> check l lt <*> check r rt
   pure (App (k2 (App (k1 o) l (a, c1))) r (a, c2), c2)

--- a/src/Types/Infer/Class.hs
+++ b/src/Types/Infer/Class.hs
@@ -89,7 +89,7 @@ inferClass clss@(Class name ctx _ methods classAnn) = do
         impty <- silence $
           closeOver (BecauseOf clss) $
             TyPi (Implicit classConstraint) obligation
-        var@(TgName name _) <- genNameWith (classCon' <> T.singleton '$')
+        ~var@(TgName name _) <- genNameWith (classCon' <> T.singleton '$')
         pure ( singleton classAnn Superclass var impty
              , (Implicit, var, name, obligation))
 

--- a/src/Types/Infer/Constructor.hs
+++ b/src/Types/Infer/Constructor.hs
@@ -40,7 +40,7 @@ inferCon ret c@(GeneralisedCon nm cty ann) = do
 
   let generalise (TyPi q t) = TyPi q <$> generalise t
       generalise ty = do
-        (sub, _, []) <- condemn $ solve (Seq.singleton (ConUnify (BecauseOf c) var ret ty))
+        ~(sub, _, []) <- condemn $ solve (Seq.singleton (ConUnify (BecauseOf c) var ret ty))
         tell (map (\(x, y) -> (TyVar x, y)) (Map.toAscList sub))
         pure ret
 

--- a/src/Types/Kinds.hs
+++ b/src/Types/Kinds.hs
@@ -172,8 +172,8 @@ inferKind (TyOperator left op right) = do
     Just k ->
       view _3 <$> instantiate Expression k
 
-  (Anon lt, c1, _) <- quantifier reason ty
-  (Anon rt, c2, _) <- quantifier reason c1
+  ~(Anon lt, c1, _) <- quantifier reason ty
+  ~(Anon rt, c2, _) <- quantifier reason c1
   left <- checkKind left lt
   right <- checkKind right rt
   pure (TyOperator left op right, c2)

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -518,7 +518,7 @@ subsumes' r scope ot@(TyTuple a b) nt@(TyTuple a' b') = do
     pure (wb, wa)
   -- Thus "point-wise" subsumption
 
-  [elem, elem'] <- replicateM 2 genName
+  ~[elem, elem'] <- replicateM 2 genName
   let cont (Tuple (e:es) (an, _)) =
         Tuple [ ExprWrapper wa e (an, a')
               , case es of


### PR DESCRIPTION
This means we have to make several patterns unconditional (by adding `~`). On the flip side, it means we're a little more explicit on what is meant to be a complete pattern and what is not.

There are several reasons for this:
 - Generating fresh names has little to do whether the current monad can fail.
 - Using `runNameyT` inside a monad transformer requires that the parent transformer has a `MoandFail` instance, which can get a little annoying.