### PR TITLE
Improvements to foreign codegen

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -222,6 +222,7 @@ library amulet
                      -- Backend
                      , Backend.Lua
                      , Backend.Lua.Emit
+                     , Backend.Lua.Inline
                      , Backend.Lua.Builtin
                      , Backend.Lua.Postprocess
                      , Backend.Escape

--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -222,6 +222,7 @@ library amulet
                      -- Backend
                      , Backend.Lua
                      , Backend.Lua.Emit
+                     , Backend.Lua.Builtin
                      , Backend.Lua.Postprocess
                      , Backend.Escape
                      -- Lua

--- a/compiler/Repl.hs
+++ b/compiler/Repl.hs
@@ -221,7 +221,7 @@ runRepl = do
               case code of
                 L.OK -> do
                   vs' <- for vs $ \(v, _) -> do
-                    let Just vs = VarMap.lookup v (emit' ^. B.topVars)
+                    let Just (_, vs) = VarMap.lookup v (emit' ^. B.topVars)
                     repr <- traverse (valueRepr . L.getglobal . T.unpack . \(LuaName n) -> n) vs
                     let CoVar id nam _ = v
                         var = S.TgName nam id

--- a/src/Backend/Lua.hs
+++ b/src/Backend/Lua.hs
@@ -23,7 +23,7 @@ import Core.Var
 -- statement
 compileProgram :: IsVar a => [Stmt a] -> LuaStmt
 compileProgram
-  = LuaDo
-  . addBuiltins
-  . toList . flip evalState defaultEmitState . emitStmt
+  = LuaDo . toList . fst
+  . uncurry addBuiltins
+  . flip runState defaultEmitState . emitStmt
   . snd. tagOccurStmt (const occursSet) OccursVar

--- a/src/Backend/Lua/Builtin.hs
+++ b/src/Backend/Lua/Builtin.hs
@@ -44,13 +44,13 @@ builtinVars :: ExtraVars
 builtinVars = VarMap.fromList $ map (\(v, _, d, _, s) -> (v, (d, Seq.fromList s))) builtins
 
 -- | All native "builders"
-builtinBuilders :: VarMap.Map ((Int, [LuaExpr] -> [LuaExpr]), LuaVar)
+builtinBuilders :: VarMap.Map ((Int, [LuaExpr] -> (Seq LuaStmt, [LuaExpr])), LuaVar)
 builtinBuilders = foldr go mempty builtins where
   go (_, _, _, Nothing, _) m = m
   go (v, n, _, Just b, _)  m = VarMap.insert v (b, LuaName n) m
 
 builtins :: [( CoVar, T.Text, [CoVar]
-             , Maybe (Int, [LuaExpr] -> [LuaExpr])
+             , Maybe (Int, [LuaExpr] -> (Seq LuaStmt, [LuaExpr]))
              , [LuaStmt] )]
 builtins =
   [ ( vLAZY, "__builtin_Lazy", [], Nothing
@@ -96,7 +96,7 @@ builtins =
           name_ = LuaName name
           inner = LuaBinOp (LuaRef left) op (LuaRef right)
       in ( var, name, []
-         , Just (2, \[l, r] -> [LuaBinOp l op r])
+         , Just (2, \[l, r] -> (mempty, [LuaBinOp l op r]))
          , [luaStmts|local function $name_($left, $right) return %inner end|] )
     left  = LuaName "l"
     right = LuaName "r"

--- a/src/Backend/Lua/Builtin.hs
+++ b/src/Backend/Lua/Builtin.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
+
+{-|A collection of all builtin variables which Amulet might use
+-}
+module Backend.Lua.Builtin
+  ( ExtraVars, builtinVars
+  , builtinEscape
+  , builtinBuilders
+  ) where
+
+import Control.Lens
+
+import qualified Data.VarMap as VarMap
+import qualified Data.Sequence as Seq
+import qualified Data.Text as T
+import Data.Sequence (Seq)
+
+import Core.Builtin
+import Core.Var
+
+import Language.Lua.Syntax
+import Language.Lua.Quote
+
+import Backend.Escape
+
+-- | The basic escaper for Lua code bases
+escaper :: T.Text -> T.Text
+escaper = basicEscaper keywords
+
+-- | The default 'EscapeScope' for the backend.
+builtinEscape:: EscapeScope
+builtinEscape
+  = flip createEscape escaper
+  . ((vError, "error"):)
+  $ map (\(v, n, _, _, _) -> (v, n)) builtins
+
+-- | A set of variables which will be lazilly emitted by the backend.
+--
+-- See "Backend.Emit.Postprocess" for more information.
+type ExtraVars = VarMap.Map ([CoVar], Seq LuaStmt)
+
+-- | The default 'ExtraVars' for the backend.
+builtinVars :: ExtraVars
+builtinVars = VarMap.fromList $ map (\(v, _, d, _, s) -> (v, (d, Seq.fromList s))) builtins
+
+-- | All native "builders"
+builtinBuilders :: VarMap.Map ((Int, [LuaExpr] -> [LuaExpr]), LuaVar)
+builtinBuilders = foldr go mempty builtins where
+  go (_, _, _, Nothing, _) m = m
+  go (v, n, _, Just b, _)  m = VarMap.insert v (b, LuaName n) m
+
+builtins :: [( CoVar, T.Text, [CoVar]
+             , Maybe (Int, [LuaExpr] -> [LuaExpr])
+             , [LuaStmt] )]
+builtins =
+  [ ( vLAZY, "__builtin_Lazy", [], Nothing
+      -- Lazy doesn't technically _need_ a tag, and including it in fact
+      -- raises the memory usage of things. But, the REPL is taught to
+      -- recognise __tag fields and print them as constructors, and so
+      -- this looks better.
+    , [luaStmts|
+      local function __builtin_Lazy(x)
+        return { x, false, __tag = "lazy" }
+      end
+      |] )
+  , ( vForce, "__builtin_force", [vUnit], Nothing
+    , [luaStmts|
+       local function __builtin_force_err()
+         error("Loop while forcing thunk")
+       end
+       local function __builtin_force(x)
+         if x[2] then
+           return x[1]
+         else
+           local thunk = x[1]
+           x[1] = __builtin_force_err
+           x[1] = thunk(__builtin_unit)
+           x[2] = true
+           return x[1]
+         end
+       end
+      |] )
+  , ( vOpApp, "__builtin_app", [], Nothing
+    , [luaStmts|
+      local function __builtin_app(f, x)
+        return f(x)
+      end
+    |] )
+  , ( vUnit, "__builtin_unit", [], Nothing
+    , [luaStmts|local __builtin_unit = { __tag = "__builtin_unit" }|] )
+  ] ++ map genOp ops
+
+  where
+    genOp (var, op) =
+      let name = escaper (var ^. covarName)
+          name_ = LuaName name
+          inner = LuaBinOp (LuaRef left) op (LuaRef right)
+      in ( var, name, []
+         , Just (2, \[l, r] -> [LuaBinOp l op r])
+         , [luaStmts|local function $name_($left, $right) return %inner end|] )
+    left  = LuaName "l"
+    right = LuaName "r"
+
+    ops :: [(CoVar, T.Text)]
+    ops =
+      [ (vOpAdd, "+"),  (vOpAddF, "+")
+      , (vOpSub, "-"),  (vOpSubF, "-")
+      , (vOpMul, "*"),  (vOpMulF, "*")
+      , (vOpDiv, "/"),  (vOpDivF, "/")
+      , (vOpExp, "^"),  (vOpExpF, "^")
+      , (vOpLt,  "<"),  (vOpLtF,  "<")
+      , (vOpGt,  ">"),  (vOpGtF,  "<")
+      , (vOpLe,  "<="), (vOpLeF,  "<=")
+      , (vOpGe,  ">="), (vOpGeF,  ">=")
+
+      , (vOpConcat, "..")
+
+      , (vOpEq, "==")
+      , (vOpNe, "~=")
+      ]

--- a/src/Backend/Lua/Inline.hs
+++ b/src/Backend/Lua/Inline.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE TemplateHaskell, FlexibleContexts #-}
+module Backend.Lua.Inline
+  ( shouldInline
+  , substExpr
+  ) where
+
+import Control.Monad.State.Strict
+import Control.Applicative
+import Control.Lens
+
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Data.Foldable
+import Data.Monoid
+
+import Language.Lua.Syntax
+
+data InlineState
+  = IS { _pendingVars :: [LuaVar]
+       , _skippedVars :: [LuaVar]
+       }
+
+makeLenses ''InlineState
+
+threshold :: Int
+threshold = 10
+
+-- | Determine if an expression should be inlined
+--
+-- We require the following to hold for an expression to be inlinable:
+--
+--  - Every argument is used exactly once, and in the order that it was
+--    passed. This requirement is a little harsh, but our current
+--    handling of unboxed tuples necessitates it.
+--
+--  - The entire body has a "size" less than or equal to the 'threshold'.
+shouldInline :: [LuaVar] -> [LuaStmt] -> Bool
+shouldInline args stmts =
+  case runStateT (foldMapM sizeStmt stmts) (IS args mempty) of
+    Just (Sum n, IS [] []) | n <= threshold -> True
+    _ -> False
+
+  where
+  sizeStmt :: ( MonadState InlineState m
+              , Alternative m )
+           => LuaStmt -> m (Sum Int)
+  -- These mess with scoping, so we'll just skip for now
+  sizeStmt LuaDo{} = empty
+  sizeStmt LuaLocal{} = empty
+  sizeStmt LuaLocalFun{} = empty
+  -- Anything which messes with control flow isn't worth bothering with.
+  sizeStmt LuaWhile{} = empty
+  sizeStmt LuaRepeat{} = empty
+  sizeStmt LuaFornum{} = empty
+  sizeStmt LuaFor{} = empty
+  sizeStmt LuaIfElse{} = empty
+  sizeStmt LuaBreak{} = empty
+  -- Impossible!
+  sizeStmt LuaQuoteS{} = empty
+
+  sizeStmt (LuaReturn r) = foldMapM sizeExpr r
+  sizeStmt (LuaCallS c) = sizeCall c
+  sizeStmt (LuaAssign as vs) = (<>) <$> foldMapM sizeAssign as <*> foldMapM sizeExpr vs
+
+  -- We skip assignments to arguments, otherwise all is good
+  sizeAssign v@LuaName{} | Set.member v allVars = empty
+  sizeAssign a = sizeExpr (LuaRef a)
+
+  sizeExpr :: ( MonadState InlineState m
+              , Alternative m )
+           => LuaExpr -> m (Sum Int)
+  -- Basic literals
+  sizeExpr LuaNil = k 1
+  sizeExpr LuaTrue = k 1
+  sizeExpr LuaFalse = k 1
+  sizeExpr LuaDots = empty
+  sizeExpr LuaNumber{} = k 1
+  sizeExpr LuaInteger{} = k 1
+  sizeExpr (LuaString s)
+    | T.length s <= 16 = k 2
+    | otherwise = empty
+  -- Just the sum of their parts plus some extra constant
+  sizeExpr (LuaBinOp l _ r) = ex 1 $ (<>) <$> sizeExpr l <*> sizeExpr r
+  sizeExpr (LuaUnOp _ o) = ex 1 $ sizeExpr o
+  sizeExpr (LuaTable fs) = ex 2 $ foldMapM (\(a, b) -> (<>) <$> sizeExpr a <*> sizeExpr b) fs
+  sizeExpr (LuaCallE c) = sizeCall c
+  sizeExpr (LuaRef (LuaIndex t f)) = ex 1 $ (<>) <$> sizeExpr t <*> sizeExpr f
+
+  sizeExpr (LuaRef v@LuaName{})
+    -- References to non-argument variables are fine.
+    | Set.notMember v allVars = k 1
+    | otherwise = do
+        vs <- use pendingVars
+        case span (/=v) vs of
+          -- The variable has already been seen, so we can't inline
+          (_, []) -> empty
+          -- Otherwise, extend the unnused set and pop the pending one.
+          (skipped, _:pending) -> do
+            pendingVars .= pending
+            skippedVars %= (skipped++)
+            k 0
+
+  -- Skip functions, as they mess with scoping
+  sizeExpr LuaFunction{} = empty
+  -- Impossible!
+  sizeExpr LuaQuoteE{} = empty
+  sizeExpr LuaBitE{} = empty
+  sizeExpr (LuaRef LuaQuoteV{}) = empty
+
+  sizeCall (LuaCall f as) = ex 2 $ foldMapM sizeExpr (f:as)
+  sizeCall (LuaInvoke t _ as) = ex 3 $ foldMapM sizeExpr (t:as)
+
+  k :: Applicative m => Int -> m (Sum Int)
+  k = pure . Sum
+
+  ex :: Functor f => Int -> f (Sum Int) -> f (Sum Int)
+  ex a b = (Sum a<>) <$> b
+
+  foldMapM f = foldrM (\a b -> (<>b) <$> f a) mempty
+
+  allVars :: Set.Set LuaVar
+  allVars = Set.fromList args
+
+-- | Substitute a series of variables within a Lua statement.
+substStmt :: Map.Map LuaVar LuaExpr -> LuaStmt -> LuaStmt
+substStmt = error "No, u"
+
+substVar :: Map.Map LuaVar LuaExpr -> LuaVar -> LuaVar
+substVar _ v@LuaName{} = v
+substVar _ v@LuaQuoteV{} = v
+substVar s (LuaIndex t f) = LuaIndex (substExpr s t) (substExpr s f)
+
+-- | Substitute a series of variables within a Lua expression.
+substExpr :: Map.Map LuaVar LuaExpr -> LuaExpr -> LuaExpr
+substExpr s = go where
+  go n@(LuaRef v@LuaName{}) = Map.findWithDefault n v s
+  go (LuaRef r) = LuaRef (substVar s r)
+
+  go n@LuaNil = n
+  go n@LuaTrue = n
+  go n@LuaFalse = n
+  go n@LuaDots = n
+  go n@LuaNumber{} = n
+  go n@LuaInteger{} = n
+  go n@LuaString{} = n
+  go n@LuaBitE{} = n
+  go n@LuaQuoteE{} = n
+
+  go (LuaTable fs) = LuaTable $ map (bimap go go) fs
+  go (LuaBinOp l o r) = LuaBinOp (go l) o (go r)
+  go (LuaUnOp o r) = LuaUnOp o (go r)
+  go (LuaCallE c) = LuaCallE (substCall s c)
+  go (LuaFunction as ss) =
+    let s' = foldr Map.delete s as
+    in LuaFunction as (map (substStmt s') ss)
+
+substCall :: Map.Map LuaVar LuaExpr -> LuaCall -> LuaCall
+substCall s (LuaCall f as) = LuaCall (substExpr s f) (map (substExpr s) as)
+substCall s (LuaInvoke t f as) = LuaInvoke (substExpr s t) f (map (substExpr s) as)

--- a/src/Backend/Lua/Postprocess.hs
+++ b/src/Backend/Lua/Postprocess.hs
@@ -1,42 +1,51 @@
 {-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
 
 {-|Handles post-processing the generated Lua sources, injecting any
- additional code which may be needed and (potentially) doing some basic
- optimisations.
+ additional code which may be needed.
+
+ We only emit some definitions when they are required by the rest of the
+ program, rather than unconditionally emitting them. This prevents us
+ from emitting 20+ functions for every builtin definition.
+
+ In order to do this, we build a map of variables -> definitions, and run
+ a separate pass after generation to add those definitions in if
+ required.
+
+ For now, we optionally emit some foreign declarations, constructors and
+ all builtins, as their usages may be elided during code generation. Any
+ other definition will have already been stripped by the optimiser, and
+ so it is not safe to remove them.
 -}
-module Backend.Lua.Postprocess
-  ( addBuiltins
-  , genBuiltin
-  , builtinVars
-  ) where
+module Backend.Lua.Postprocess (addBuiltins) where
+
+import Control.Lens
 
 import qualified Data.VarSet as VarSet
 import qualified Data.VarMap as VarMap
 import qualified Data.Map as Map
+import Data.Sequence (Seq)
+import Data.Tuple
 
 import Language.Lua.Syntax
-import Language.Lua.Quote
 
+import Backend.Lua.Builtin (ExtraVars)
 import Backend.Lua.Emit
 import Backend.Escape
-import Core.Builtin
-import Core.Var
 
+import Core.Var
 
 -- | Walks the Lua tree and identifies which builtins are not fully
 -- applied (and so their variable is referenced), injecting them into the
 -- program.
-addBuiltins :: [LuaStmt] -> [LuaStmt]
-addBuiltins stmt = snd (genBuiltins (VarSet.toList (foldMap opsStmt stmt)) mempty stmt)
+addBuiltins ::  Seq LuaStmt -> TopEmitState -> (Seq LuaStmt, TopEmitState)
+addBuiltins stmt state = fmap (flip (set topExVars) state) . swap
+                       $ genBuiltins (VarSet.toList (foldMap opsStmt stmt)) (state ^. topExVars) stmt
   where
-    genBuiltins :: [CoVar] -> VarSet.Set -> [LuaStmt] -> (VarSet.Set, [LuaStmt])
+    genBuiltins :: [CoVar] -> ExtraVars -> Seq LuaStmt -> (ExtraVars, Seq LuaStmt)
     genBuiltins [] vs ss = (vs, ss)
-    genBuiltins (b:bs) vs ss
-      | b `VarSet.member` vs = genBuiltins bs vs ss
-      | otherwise =
-          let (deps, stmts) = genBuiltin b
-              (vs', ss') = genBuiltins deps vs (stmts ++ ss)
-          in genBuiltins bs vs' ss'
+    genBuiltins (b:bs) vs ss = case VarMap.lookup b vs of
+      Nothing -> genBuiltins bs vs ss
+      Just (deps, stmts) -> genBuiltins (deps ++ bs) (VarMap.delete b vs) (stmts <> ss)
 
     opsStmt :: LuaStmt -> VarSet.Set
     opsStmt (LuaDo b) = foldMap opsStmt b
@@ -72,64 +81,11 @@ addBuiltins stmt = snd (genBuiltins (VarSet.toList (foldMap opsStmt stmt)) mempt
     opsExpr (LuaUnOp _ x) = opsExpr x
 
     opsVar :: LuaVar -> VarSet.Set
-    opsVar (LuaName t) = foldMap VarSet.singleton (Map.lookup t opNames)
+    opsVar (LuaName t) = foldMap VarSet.singleton (Map.lookup t usedNames)
     opsVar (LuaIndex t k) = opsExpr t <> opsExpr k
     opsVar LuaQuoteV{} = mempty
 
     opsCall (LuaCall f xs) = foldMap opsExpr (f:xs)
     opsCall (LuaInvoke f _ xs) = foldMap opsExpr (f:xs)
 
-    opNames =  Map.filter (`VarMap.member` builtinVars) (fromEsc escapeScope)
-
--- | Generate the Lua definition for some built-in Amulet variable.
-genBuiltin :: CoVar -> ([CoVar], [LuaStmt])
-genBuiltin op | op == vLAZY =
-  ( []
-  , [luaStmts|
-    local function __builtin_Lazy(x)
-      return { x, false, __tag = "lazy" }
-    end
-  |] )
-genBuiltin op | op == vOpApp =
-  ( []
-  , [luaStmts|
-    local function __builtin_app(f, x)
-      return f(x)
-    end
-  |] )
-genBuiltin op | op == vForce =
-  ( [ vUnit ]
-  , [luaStmts|
-   local function __builtin_force_err()
-     error("Loop while forcing thunk")
-   end
-   local function __builtin_force(x)
-     if x[2] then
-       return x[1]
-     else
-       local thunk = x[1]
-       x[1] = __builtin_force_err
-       x[1] = thunk(__builtin_unit)
-       x[2] = true
-       return x[1]
-     end
-   end
-  |] )
-genBuiltin op | op == vUnit =
-  ( []
-  , [luaStmts|local  __builtin_unit = { __tag = "__builtin_unit" }|] )
-genBuiltin op =
-  let name =  getVar op escapeScope
-  in ( [], [LuaLocalFun (LuaName name) [left]
-              [LuaReturn [LuaFunction [right]
-                           [LuaReturn [LuaBinOp (LuaRef left) (remapOp op) (LuaRef right)]]]]] )
-  where
-    left  = LuaName "l"
-    right = LuaName "r"
-
-{- Note: Tags on Lazy
-
-   Lazy doesn't technically _need_ a tag, and including it in fact
-   raises the memory usage of things. But, the REPL is taught to
-   recognise __tag fields and print them as constructors, and so this
-   looks better. -}
+    usedNames =  Map.filter (`VarMap.member` (state ^. topExVars)) (fromEsc (state ^. topEscape))

--- a/src/Backend/Lua/Postprocess.hs
+++ b/src/Backend/Lua/Postprocess.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings, QuasiQuotes #-}
-
 {-|Handles post-processing the generated Lua sources, injecting any
  additional code which may be needed.
 

--- a/src/Language/Lua/Syntax.hs
+++ b/src/Language/Lua/Syntax.hs
@@ -172,7 +172,7 @@ instance Pretty LuaVar where
   pretty (LuaName x) = text x
   pretty (LuaIndex e (LuaString k))
     | validKey k = prettyWith PreRaw e <> dot <> text k
-  pretty (LuaIndex e k) = pretty e <> brackets (pretty k)
+  pretty (LuaIndex e k) = prettyWith PreRaw e <> brackets (pretty k)
   pretty (LuaQuoteV x) = "$" <> text x
 
 instance Pretty LuaExpr where

--- a/tests/lua/and.lua
+++ b/tests/lua/and.lua
@@ -1,5 +1,5 @@
 do
   local function main(f) return f(1) and f(2) end
   local bottom = nil
-  bottom(main)
+  (nil)(main)
 end

--- a/tests/lua/and.lua
+++ b/tests/lua/and.lua
@@ -1,5 +1,4 @@
 do
   local function main(f) return f(1) and f(2) end
-  local bottom = nil
   (nil)(main)
 end

--- a/tests/lua/arithmetic.lua
+++ b/tests/lua/arithmetic.lua
@@ -1,4 +1,3 @@
 do
-  local bottom = nil
   (nil)((nil)(1) + (nil)(2))
 end

--- a/tests/lua/arithmetic.lua
+++ b/tests/lua/arithmetic.lua
@@ -1,4 +1,5 @@
 do
   local bottom = nil
-  bottom(bottom(1) + bottom(2))
+  local cr = nil
+  (nil)(cr(1) + cr(2))
 end

--- a/tests/lua/arithmetic.lua
+++ b/tests/lua/arithmetic.lua
@@ -1,5 +1,4 @@
 do
   local bottom = nil
-  local cr = nil
-  (nil)(cr(1) + cr(2))
+  (nil)((nil)(1) + (nil)(2))
 end

--- a/tests/lua/as_pattern.lua
+++ b/tests/lua/as_pattern.lua
@@ -4,5 +4,5 @@ do
     return b.a + b.b + ch.c
   end
   local bottom = nil
-  bottom(main)
+  (nil)(main)
 end

--- a/tests/lua/as_pattern.lua
+++ b/tests/lua/as_pattern.lua
@@ -3,6 +3,5 @@ do
     local b = ch.a
     return b.a + b.b + ch.c
   end
-  local bottom = nil
   (nil)(main)
 end

--- a/tests/lua/emit_ifs.lua
+++ b/tests/lua/emit_ifs.lua
@@ -7,14 +7,14 @@ do
   local function _not(a) return not a end
   (nil)({ ands = _amp_amp, ors = _bar_bar, ["not"] = _not })
   (nil)(function(gs)
-    if bool then
+    if true then
       return print("L")
     end
     print("R")
     return print("R")
   end)
   (nil)(function(hd)
-    if not bool then
+    if not true then
       return print("R")
     end
     print("L")

--- a/tests/lua/emit_ifs.lua
+++ b/tests/lua/emit_ifs.lua
@@ -1,7 +1,5 @@
 do
-  local bottom = nil
   local print = print
-  local bool = true
   local function _amp_amp(a) return function(b) return a and b end end
   local function _bar_bar(a) return function(b) return a or b end end
   local function _not(a) return not a end

--- a/tests/lua/emit_ifs.lua
+++ b/tests/lua/emit_ifs.lua
@@ -5,25 +5,25 @@ do
   local function _amp_amp(a) return function(b) return a and b end end
   local function _bar_bar(a) return function(b) return a or b end end
   local function _not(a) return not a end
-  bottom({ ands = _amp_amp, ors = _bar_bar, ["not"] = _not })
-  bottom(function(gs)
+  (nil)({ ands = _amp_amp, ors = _bar_bar, ["not"] = _not })
+  (nil)(function(gs)
     if bool then
       return print("L")
     end
     print("R")
     return print("R")
   end)
-  bottom(function(hd)
+  (nil)(function(hd)
     if not bool then
       return print("R")
     end
     print("L")
     return print("L")
   end)
-  if bool then
+  if true then
     print("Hello")
   end
-  if not bool then
+  if not true then
     print("Hello")
   end
 end

--- a/tests/lua/escape.lua
+++ b/tests/lua/escape.lua
@@ -1,4 +1,3 @@
 do
-  local bottom = nil
   (nil)({ quote = "\"", line = "\n", tab = "\t", hex = "\17" })
 end

--- a/tests/lua/escape.lua
+++ b/tests/lua/escape.lua
@@ -1,4 +1,4 @@
 do
   local bottom = nil
-  bottom({ quote = "\"", line = "\n", tab = "\t", hex = "\17" })
+  (nil)({ quote = "\"", line = "\n", tab = "\t", hex = "\17" })
 end

--- a/tests/lua/external.lua
+++ b/tests/lua/external.lua
@@ -1,5 +1,5 @@
 do
   local rem = function(x, y) return x % y end
   local bottom = nil
-  bottom(rem(5, 3))
+  (nil)(rem(5, 3))
 end

--- a/tests/lua/external.lua
+++ b/tests/lua/external.lua
@@ -1,5 +1,4 @@
 do
   local rem = function(x, y) return x % y end
-  local bottom = nil
   (nil)(rem(5, 3))
 end

--- a/tests/lua/external.lua
+++ b/tests/lua/external.lua
@@ -1,4 +1,3 @@
 do
-  local rem = function(x, y) return x % y end
-  (nil)(rem(5, 3))
+  (nil)(5 % 3)
 end

--- a/tests/lua/function_order.lua
+++ b/tests/lua/function_order.lua
@@ -1,7 +1,8 @@
 do
   local bottom = nil
-  local a = bottom(1)
-  local b = bottom(2)
-  local c = bottom(3)
-  bottom(b)(c)(a)
+  local dk = nil
+  local a = dk(1)
+  local b = dk(2)
+  local c = dk(3)
+  (nil)(b)(c)(a)
 end

--- a/tests/lua/function_order.lua
+++ b/tests/lua/function_order.lua
@@ -1,8 +1,7 @@
 do
   local bottom = nil
-  local dk = nil
-  local a = dk(1)
-  local b = dk(2)
-  local c = dk(3)
+  local a = (nil)(1)
+  local b = (nil)(2)
+  local c = (nil)(3)
   (nil)(b)(c)(a)
 end

--- a/tests/lua/function_order.lua
+++ b/tests/lua/function_order.lua
@@ -1,5 +1,4 @@
 do
-  local bottom = nil
   local a = (nil)(1)
   local b = (nil)(2)
   local c = (nil)(3)

--- a/tests/lua/if.lua
+++ b/tests/lua/if.lua
@@ -1,5 +1,4 @@
 do
-  local bottom = nil
   if (nil)(1) then
     (nil)((nil)(2))
   else

--- a/tests/lua/if.lua
+++ b/tests/lua/if.lua
@@ -1,10 +1,8 @@
 do
   local bottom = nil
-  local bh = nil
-  local bg = nil
-  if bh(1) then
-    bg(bh(2))
+  if (nil)(1) then
+    (nil)((nil)(2))
   else
-    bg(bh(3))
+    (nil)((nil)(3))
   end
 end

--- a/tests/lua/if.lua
+++ b/tests/lua/if.lua
@@ -1,8 +1,10 @@
 do
   local bottom = nil
-  if bottom(1) then
-    bottom(bottom(2))
+  local bh = nil
+  local bg = nil
+  if bh(1) then
+    bg(bh(2))
   else
-    bottom(bottom(3))
+    bg(bh(3))
   end
 end

--- a/tests/lua/inline_external.lua
+++ b/tests/lua/inline_external.lua
@@ -1,0 +1,10 @@
+do
+  local set = function(x, y)
+    x[1] = y
+  end
+  local print = print
+  local r = { 0 }
+  print(r[1])
+  set(r, 1)
+  print(r[1])
+end

--- a/tests/lua/inline_external.lua
+++ b/tests/lua/inline_external.lua
@@ -1,10 +1,7 @@
 do
-  local set = function(x, y)
-    x[1] = y
-  end
   local print = print
   local r = { 0 }
   print(r[1])
-  set(r, 1)
+  r[1] = 1
   print(r[1])
 end

--- a/tests/lua/inline_external.ml
+++ b/tests/lua/inline_external.ml
@@ -1,0 +1,13 @@
+module Ref =
+  type ref 'a
+  external val new : 'a -> ref 'a = "function(x) return { x } end"
+  external val get : ref 'a -> 'a = "function(x) return x[1] end"
+  external val set : ref 'a -> 'a -> () = "function(x, y) x[1] = y end"
+
+external val print : 'a -> () = "print"
+
+let () =
+  let r = Ref.new 0
+  print (Ref.get r)
+  r `Ref.set` 1
+  print (Ref.get r)

--- a/tests/lua/lazy.lua
+++ b/tests/lua/lazy.lua
@@ -16,7 +16,7 @@ do
     end
   end
   local bottom = nil
-  bottom({
+  (nil)({
     _1 = __builtin_Lazy(function(ae) return 2 end),
     _2 = function(x) return __builtin_force(x) end
   })

--- a/tests/lua/lazy.lua
+++ b/tests/lua/lazy.lua
@@ -15,7 +15,6 @@ do
       return x[1]
     end
   end
-  local bottom = nil
   (nil)({
     _1 = __builtin_Lazy(function(ae) return 2 end),
     _2 = function(x) return __builtin_force(x) end

--- a/tests/lua/let_pattern.lua
+++ b/tests/lua/let_pattern.lua
@@ -1,5 +1,4 @@
 do
   local el = { _1 = function(x) return x end, _2 = function(x) return x end }
-  local bottom = nil
   (nil)({ a = 3, b = 5, c = 6, d = el._1, e = el._2 })
 end

--- a/tests/lua/let_pattern.lua
+++ b/tests/lua/let_pattern.lua
@@ -1,5 +1,5 @@
 do
   local el = { _1 = function(x) return x end, _2 = function(x) return x end }
   local bottom = nil
-  bottom({ a = 3, b = 5, c = 6, d = el._1, e = el._2 })
+  (nil)({ a = 3, b = 5, c = 6, d = el._1, e = el._2 })
 end

--- a/tests/lua/match_consumed.lua
+++ b/tests/lua/match_consumed.lua
@@ -2,10 +2,13 @@ do
   local None = { __tag = "None" }
   local function Some(x) return { __tag = "Some", x } end
   local bottom = nil
-  local a = bottom(1)
-  if bottom.__tag == "None" then
-    bottom(bottom(a))
-  elseif bottom.__tag == "Some" then
-    bottom(bottom(a + bottom[1] * 2))
+  local eb = nil
+  local ea = nil
+  local ed = nil
+  local a = eb(1)
+  if ed.__tag == "None" then
+    ea(eb(a))
+  elseif ed.__tag == "Some" then
+    ea(eb(a + ed[1] * 2))
   end
 end

--- a/tests/lua/match_consumed.lua
+++ b/tests/lua/match_consumed.lua
@@ -2,13 +2,10 @@ do
   local None = { __tag = "None" }
   local function Some(x) return { __tag = "Some", x } end
   local bottom = nil
-  local eb = nil
-  local ea = nil
-  local ed = nil
-  local a = eb(1)
-  if ed.__tag == "None" then
-    ea(eb(a))
-  elseif ed.__tag == "Some" then
-    ea(eb(a + ed[1] * 2))
+  local a = (nil)(1)
+  if (nil).__tag == "None" then
+    (nil)((nil)(a))
+  elseif (nil).__tag == "Some" then
+    (nil)((nil)(a + (nil)[1] * 2))
   end
 end

--- a/tests/lua/match_consumed.lua
+++ b/tests/lua/match_consumed.lua
@@ -1,7 +1,4 @@
 do
-  local None = { __tag = "None" }
-  local function Some(x) return { __tag = "Some", x } end
-  local bottom = nil
   local a = (nil)(1)
   if (nil).__tag == "None" then
     (nil)((nil)(a))

--- a/tests/lua/match_heuristic.lua
+++ b/tests/lua/match_heuristic.lua
@@ -57,5 +57,5 @@ do
     end
   end
   local bottom = nil
-  bottom({ common_prefix = common_prefix, common_suffix = common_suffix, mixed_1 = mixed_1 })
+  (nil)({ common_prefix = common_prefix, common_suffix = common_suffix, mixed_1 = mixed_1 })
 end

--- a/tests/lua/match_heuristic.lua
+++ b/tests/lua/match_heuristic.lua
@@ -1,6 +1,4 @@
 do
-  local Nil = { __tag = "Nil" }
-  local function Cons(x) return { __tag = "Cons", x } end
   local function common_prefix(j)
     local eu = j._1
     local et = j._2
@@ -56,6 +54,5 @@ do
       end
     end
   end
-  local bottom = nil
   (nil)({ common_prefix = common_prefix, common_suffix = common_suffix, mixed_1 = mixed_1 })
 end

--- a/tests/lua/match_multi.lua
+++ b/tests/lua/match_multi.lua
@@ -1,6 +1,5 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
-  local bottom = nil
   local bo = (nil)(__builtin_unit)
   (nil)(bo.a + bo.b)
 end

--- a/tests/lua/match_multi.lua
+++ b/tests/lua/match_multi.lua
@@ -1,6 +1,6 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
-  local bo = bottom(__builtin_unit)
-  bottom(bo.a + bo.b)
+  local bo = (nil)(__builtin_unit)
+  (nil)(bo.a + bo.b)
 end

--- a/tests/lua/monoid.lua
+++ b/tests/lua/monoid.lua
@@ -1,5 +1,7 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
+  local Nil = { __tag = "Nil" }
+  local function Cons(x) return { __tag = "Cons", x } end
   local tostring = tostring
   local writeln = print
   local function _dollardApplicativeafj(ahb)
@@ -9,8 +11,6 @@ do
       ["Applicative$kp"] = _dollardApplicativeafj(ahb)["Applicative$kp"]
     }
   end
-  local Nil = { __tag = "Nil" }
-  local function Cons(x) return { __tag = "Cons", x } end
   local function _colon_colon(x) return function(y) return Cons({ _1 = x, _2 = y }) end end
   local function _dollardShowatm(auy)
     return function(cw)

--- a/tests/lua/mutable_table.lua
+++ b/tests/lua/mutable_table.lua
@@ -1,12 +1,9 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
-  local of_any = function(a) return a end
   local empty = function() return {} end
-  local get = function(tbl, k) return tbl[k] end
   local set = function(tbl, k, v)
     tbl[k] = v
   end
   local t = empty(__builtin_unit)
-  set(t, "foo", of_any("foo"))
-  get(t, "foo")
+  set(t, "foo", "foo")
 end

--- a/tests/lua/mutable_table.lua
+++ b/tests/lua/mutable_table.lua
@@ -1,9 +1,6 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
   local empty = function() return {} end
-  local set = function(tbl, k, v)
-    tbl[k] = v
-  end
   local t = empty(__builtin_unit)
-  set(t, "foo", "foo")
+  t.foo = "foo"
 end

--- a/tests/lua/nested_match.lua
+++ b/tests/lua/nested_match.lua
@@ -1,6 +1,6 @@
 do
-  local Nil = { __tag = "Nil" }
   local function Cons(x) return { __tag = "Cons", x } end
+  local Nil = { __tag = "Nil" }
   local function zip(f, xs, ys)
     if xs.__tag == "Nil" then
       return Cons({ _1 = 1, _2 = Nil })
@@ -25,6 +25,5 @@ do
     end
   end
   local function zip0(f) return function(xs) return function(ys) return zip(f, xs, ys) end end end
-  local bottom = nil
   (nil)(zip0)
 end

--- a/tests/lua/nested_match.lua
+++ b/tests/lua/nested_match.lua
@@ -26,5 +26,5 @@ do
   end
   local function zip0(f) return function(xs) return function(ys) return zip(f, xs, ys) end end end
   local bottom = nil
-  bottom(zip0)
+  (nil)(zip0)
 end

--- a/tests/lua/nested_match_basic.lua
+++ b/tests/lua/nested_match_basic.lua
@@ -16,5 +16,5 @@ do
   end
   local function zip0(f) return function(xs) return function(ys) return zip(f, xs, ys) end end end
   local bottom = nil
-  bottom(zip0)
+  (nil)(zip0)
 end

--- a/tests/lua/nested_match_basic.lua
+++ b/tests/lua/nested_match_basic.lua
@@ -1,6 +1,6 @@
 do
-  local Nil = { __tag = "Nil" }
   local function Cons(x) return { __tag = "Cons", x } end
+  local Nil = { __tag = "Nil" }
   local function zip(f, xs, ys)
     if xs.__tag == "Nil" then
       return Cons({ _1 = 1, _2 = Nil })
@@ -15,6 +15,5 @@ do
     end
   end
   local function zip0(f) return function(xs) return function(ys) return zip(f, xs, ys) end end end
-  local bottom = nil
   (nil)(zip0)
 end

--- a/tests/lua/newtype.lua
+++ b/tests/lua/newtype.lua
@@ -2,8 +2,8 @@ do
   local function Foo(fv) return fv end
   local function It(x) return { __tag = "It", x } end
   local bottom = nil
-  bottom(Foo)
-  bottom(function(fw) return fw end)
-  bottom(It)
-  bottom(function(fx) return fx end)
+  (nil)(Foo)
+  (nil)(function(fw) return fw end)
+  (nil)(It)
+  (nil)(function(fx) return fx end)
 end

--- a/tests/lua/newtype.lua
+++ b/tests/lua/newtype.lua
@@ -1,7 +1,6 @@
 do
-  local function Foo(fv) return fv end
   local function It(x) return { __tag = "It", x } end
-  local bottom = nil
+  local function Foo(fv) return fv end
   (nil)(Foo)
   (nil)(function(fw) return fw end)
   (nil)(It)

--- a/tests/lua/op_apply.lua
+++ b/tests/lua/op_apply.lua
@@ -1,6 +1,6 @@
 do
   local bottom = nil
-  bottom({
+  (nil)({
     op = function(ci) return ci end,
     app = 2,
     rsec = function(e) return e(2) end,

--- a/tests/lua/op_apply.lua
+++ b/tests/lua/op_apply.lua
@@ -1,5 +1,4 @@
 do
-  local bottom = nil
   (nil)({
     op = function(ci) return ci end,
     app = 2,

--- a/tests/lua/opt_constant_fold.lua
+++ b/tests/lua/opt_constant_fold.lua
@@ -1,6 +1,6 @@
 do
   local bottom = nil
-  bottom(function(jg)
+  (nil)(function(jg)
     local i, s = jg.i, jg.s
     return {
       int_add_c = 5,

--- a/tests/lua/opt_constant_fold.lua
+++ b/tests/lua/opt_constant_fold.lua
@@ -1,5 +1,4 @@
 do
-  local bottom = nil
   (nil)(function(jg)
     local i, s = jg.i, jg.s
     return {

--- a/tests/lua/opt_dead_ctor.lua
+++ b/tests/lua/opt_dead_ctor.lua
@@ -1,3 +1,3 @@
 do
-  local function Wrapper(x) return { __tag = "Wrapper", x } end
+
 end

--- a/tests/lua/opt_inline_rec.lua
+++ b/tests/lua/opt_inline_rec.lua
@@ -1,5 +1,5 @@
 do
   local function f(x) return f(x) + 1 + 1 end
   local bottom = nil
-  bottom(f)
+  (nil)(f)
 end

--- a/tests/lua/opt_inline_rec.lua
+++ b/tests/lua/opt_inline_rec.lua
@@ -1,5 +1,4 @@
 do
   local function f(x) return f(x) + 1 + 1 end
-  local bottom = nil
   (nil)(f)
 end

--- a/tests/lua/opt_inline_tyapp.lua
+++ b/tests/lua/opt_inline_tyapp.lua
@@ -1,5 +1,4 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
-  local bottom = nil
   (nil)({ _1 = __builtin_unit, _2 = __builtin_unit })
 end

--- a/tests/lua/opt_inline_tyapp.lua
+++ b/tests/lua/opt_inline_tyapp.lua
@@ -1,5 +1,5 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
   local bottom = nil
-  bottom({ _1 = __builtin_unit, _2 = __builtin_unit })
+  (nil)({ _1 = __builtin_unit, _2 = __builtin_unit })
 end

--- a/tests/lua/opt_shadow_match.lua
+++ b/tests/lua/opt_shadow_match.lua
@@ -7,5 +7,5 @@ do
     end
   end
   local bottom = nil
-  bottom(main)
+  (nil)(main)
 end

--- a/tests/lua/opt_shadow_match.lua
+++ b/tests/lua/opt_shadow_match.lua
@@ -6,6 +6,5 @@ do
       return 4
     end
   end
-  local bottom = nil
   (nil)(main)
 end

--- a/tests/lua/opt_single_let.lua
+++ b/tests/lua/opt_single_let.lua
@@ -4,5 +4,5 @@ do
   local Z = { __tag = "Z" }
   local function g(x) return x(__builtin_unit) end
   local bottom = nil
-  bottom({ f = f, g = g })
+  (nil)({ f = f, g = g })
 end

--- a/tests/lua/opt_single_let.lua
+++ b/tests/lua/opt_single_let.lua
@@ -1,8 +1,6 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
   local function f(x) return x(__builtin_unit) end
-  local Z = { __tag = "Z" }
   local function g(x) return x(__builtin_unit) end
-  local bottom = nil
   (nil)({ f = f, g = g })
 end

--- a/tests/lua/opt_single_match.lua
+++ b/tests/lua/opt_single_match.lua
@@ -1,7 +1,5 @@
 do
   local function f(x) return x end
-  local Z = { __tag = "Z" }
   local function g(x) return x end
-  local bottom = nil
   (nil)({ f = f, g = g })
 end

--- a/tests/lua/opt_single_match.lua
+++ b/tests/lua/opt_single_match.lua
@@ -3,5 +3,5 @@ do
   local Z = { __tag = "Z" }
   local function g(x) return x end
   local bottom = nil
-  bottom({ f = f, g = g })
+  (nil)({ f = f, g = g })
 end

--- a/tests/lua/opt_unbox_args.lua
+++ b/tests/lua/opt_unbox_args.lua
@@ -5,6 +5,5 @@ do
     end
     return fib_prime(x - 1, acc * x)
   end
-  local bottom = nil
   (nil)(fib_prime(10, 1))
 end

--- a/tests/lua/opt_unbox_args.lua
+++ b/tests/lua/opt_unbox_args.lua
@@ -1,10 +1,9 @@
 do
   local function fib_prime(x, acc)
-    local db_2 = 1
-    if x <= db_2 then
+    if x <= 1 then
       return acc
     end
-    return fib_prime(x - db_2, acc * x)
+    return fib_prime(x - 1, acc * x)
   end
   local bottom = nil
   (nil)(fib_prime(10, 1))

--- a/tests/lua/opt_unbox_args.lua
+++ b/tests/lua/opt_unbox_args.lua
@@ -7,5 +7,5 @@ do
     return fib_prime(x - db_2, acc * x)
   end
   local bottom = nil
-  bottom(fib_prime(10, 1))
+  (nil)(fib_prime(10, 1))
 end

--- a/tests/lua/optimise_sink.lua
+++ b/tests/lua/optimise_sink.lua
@@ -1,6 +1,5 @@
 do
   local Nil = { __tag = "Nil" }
-  local function Cons(x) return { __tag = "Cons", x } end
   local function main(x)
     if x.__tag == "Nil" then
       return function(dy) return { _1 = 1, _2 = x } end
@@ -8,6 +7,5 @@ do
       return function(x0) return { _1 = x0, _2 = Nil } end
     end
   end
-  local bottom = nil
   (nil)(main)
 end

--- a/tests/lua/optimise_sink.lua
+++ b/tests/lua/optimise_sink.lua
@@ -9,5 +9,5 @@ do
     end
   end
   local bottom = nil
-  bottom(main)
+  (nil)(main)
 end

--- a/tests/lua/pattern_guard.lua
+++ b/tests/lua/pattern_guard.lua
@@ -15,5 +15,5 @@ do
   end
   local function filter0(f) return function(o) return filter(f, o) end end
   local bottom = nil
-  bottom(filter0)
+  (nil)(filter0)
 end

--- a/tests/lua/pattern_guard.lua
+++ b/tests/lua/pattern_guard.lua
@@ -1,6 +1,6 @@
 do
-  local Nil = { __tag = "Nil" }
   local function Cons(x) return { __tag = "Cons", x } end
+  local Nil = { __tag = "Nil" }
   local function filter(f, o)
     if o.__tag == "Nil" then
       return Nil
@@ -14,6 +14,5 @@ do
     end
   end
   local function filter0(f) return function(o) return filter(f, o) end end
-  local bottom = nil
   (nil)(filter0)
 end

--- a/tests/lua/precedence.lua
+++ b/tests/lua/precedence.lua
@@ -1,5 +1,4 @@
 do
-  local bottom = nil
   local function main(bt) return (bt.a + bt.b) * bt.c end
   (nil)(main)
 end

--- a/tests/lua/precedence.lua
+++ b/tests/lua/precedence.lua
@@ -1,5 +1,5 @@
 do
   local bottom = nil
   local function main(bt) return (bt.a + bt.b) * bt.c end
-  bottom(main)
+  (nil)(main)
 end

--- a/tests/lua/record_extend.lua
+++ b/tests/lua/record_extend.lua
@@ -1,9 +1,10 @@
 do
   local bottom = nil
   local ba = {}
-  for k, v in pairs(bottom) do
+  local __o = nil
+  for k, v in pairs(__o) do
     ba[k] = v
   end
   ba.x = 1
-  bottom(ba)
+  (nil)(ba)
 end

--- a/tests/lua/record_extend.lua
+++ b/tests/lua/record_extend.lua
@@ -1,5 +1,4 @@
 do
-  local bottom = nil
   local ba = {}
   local __o = nil
   for k, v in pairs(__o) do

--- a/tests/lua/reduce_single_constructor.lua
+++ b/tests/lua/reduce_single_constructor.lua
@@ -2,10 +2,10 @@ do
   local __builtin_unit = { __tag = "__builtin_unit" }
   local Mono = { __tag = "Mono" }
   local go = nil
-  local main = go(__builtin_unit)
+  local main = (nil)(__builtin_unit)
   local go0 = nil
-  go0(__builtin_unit)
+  (nil)(__builtin_unit)
   local main0 = 2
   local bottom = nil
-  bottom({ _1 = main, _2 = main0 })
+  (nil)({ _1 = main, _2 = main0 })
 end

--- a/tests/lua/reduce_single_constructor.lua
+++ b/tests/lua/reduce_single_constructor.lua
@@ -1,10 +1,6 @@
 do
   local __builtin_unit = { __tag = "__builtin_unit" }
-  local Mono = { __tag = "Mono" }
-  local go = nil
   local main = (nil)(__builtin_unit)
-  local go0 = nil
   (nil)(__builtin_unit)
-  local bottom = nil
   (nil)({ _1 = main, _2 = 2 })
 end

--- a/tests/lua/reduce_single_constructor.lua
+++ b/tests/lua/reduce_single_constructor.lua
@@ -5,7 +5,6 @@ do
   local main = (nil)(__builtin_unit)
   local go0 = nil
   (nil)(__builtin_unit)
-  local main0 = 2
   local bottom = nil
-  (nil)({ _1 = main, _2 = main0 })
+  (nil)({ _1 = main, _2 = 2 })
 end

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -8,5 +8,5 @@ do
     }
   }
   local bottom = nil
-  bottom(main)
+  (nil)(main)
 end

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -7,6 +7,5 @@ do
       _2 = { _1 = function(d) return d / 2 end, _2 = function(e) return e.foo end }
     }
   }
-  local bottom = nil
   (nil)(main)
 end

--- a/tests/lua/stream-zip.lua
+++ b/tests/lua/stream-zip.lua
@@ -1,12 +1,12 @@
 do
+  local None = { __tag = "None" }
+  local function Some(x) return { __tag = "Some", x } end
+  local Done = { __tag = "Done" }
+  local function Yield(x) return { __tag = "Yield", x } end
+  local function Skip(x) return { __tag = "Skip", x } end
+  local function Stream(x) return { __tag = "Stream", x } end
   local print = print
   local to_string = tostring
-  local function Skip(x) return { __tag = "Skip", x } end
-  local function Yield(x) return { __tag = "Yield", x } end
-  local Done = { __tag = "Done" }
-  local function Stream(x) return { __tag = "Stream", x } end
-  local function Some(x) return { __tag = "Some", x } end
-  local None = { __tag = "None" }
   local function zip(bfv)
     local bfx = bfv[1]
     local f, start = bfx._1, bfx._2

--- a/tests/lua/stream.lua
+++ b/tests/lua/stream.lua
@@ -16,5 +16,5 @@ do
   io_write("[")
   local main = go(1)
   local bottom = nil
-  bottom(main)
+  (nil)(main)
 end

--- a/tests/lua/stream.lua
+++ b/tests/lua/stream.lua
@@ -2,10 +2,6 @@ do
   local io_write = io.write
   local print = print
   local to_string = tostring
-  local function Skip(x) return { __tag = "Skip", x } end
-  local function Yield(x) return { __tag = "Yield", x } end
-  local Done = { __tag = "Done" }
-  local function Stream(x) return { __tag = "Stream", x } end
   local function go(st)
     if st > 5 then
       return print("]")
@@ -15,6 +11,5 @@ do
   end
   io_write("[")
   local main = go(1)
-  local bottom = nil
   (nil)(main)
 end

--- a/tests/lua/tuple_literal.lua
+++ b/tests/lua/tuple_literal.lua
@@ -1,5 +1,6 @@
 do
   local bottom = nil
-  local a = bottom(1)
-  bottom({ _1 = bottom(2), _2 = { _1 = bottom(3), _2 = a } })
+  local ct = nil
+  local a = ct(1)
+  (nil)({ _1 = ct(2), _2 = { _1 = ct(3), _2 = a } })
 end

--- a/tests/lua/tuple_literal.lua
+++ b/tests/lua/tuple_literal.lua
@@ -1,5 +1,4 @@
 do
-  local bottom = nil
   local a = (nil)(1)
   (nil)({ _1 = (nil)(2), _2 = { _1 = (nil)(3), _2 = a } })
 end

--- a/tests/lua/tuple_literal.lua
+++ b/tests/lua/tuple_literal.lua
@@ -1,6 +1,5 @@
 do
   local bottom = nil
-  local ct = nil
-  local a = ct(1)
-  (nil)({ _1 = ct(2), _2 = { _1 = ct(3), _2 = a } })
+  local a = (nil)(1)
+  (nil)({ _1 = (nil)(2), _2 = { _1 = (nil)(3), _2 = a } })
 end

--- a/tests/lua/values_occ.lua
+++ b/tests/lua/values_occ.lua
@@ -1,7 +1,7 @@
 do
+  local function Stream(x) return { __tag = "Stream", x } end
   local print = print
   local to_string = tostring
-  local function Stream(x) return { __tag = "Stream", x } end
   local function sum_squares(xs)
     local jj = xs[1]
     local go = jj._1


### PR DESCRIPTION
 - [x] Emit foreign literals inline, rather than adding a new upvalue.
 - [x] Inline trivial foreign functions. For now this'll be those which refer to each variable exactly once, in order they are passed, though this could be extended in the future.
 - [x] Use the postprocessor system for emitting foreign expressions on demand, rather than unconditionally.