### PR TITLE
Rewrite the test reporter to be less verbose and more sexy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
         stage('Run tests') {
           steps {
             timestamps () {
-              sh 'nix-shell . --run "cabal new-run test:tests -- --xml junit.xml " --arg ci true'
+              sh 'nix-shell . --run "cabal new-run test:tests -- --xml junit.xml --num-threads 4 --display t" --arg ci true'
             }
           }
         }

--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -44,6 +44,7 @@ test-suite tests
   main-is:             Test.hs
   hs-source-dirs:      compiler
   build-depends:       mtl >= 2.2 && < 2.3
+                     , stm >= 2.5 && < 2.6
                      , text >= 1.2 && < 1.3
                      , base >= 4.9 && < 4.13
                      , lens >= 4.15 && < 4.18
@@ -59,6 +60,7 @@ test-suite tests
                      , tasty-ant-xml >= 1.1 && < 1.2
                      , tasty-hedgehog >= 0.2 && < 0.3
   other-modules:       Test.Golden
+                     , Test.Reporter
                      , Test.Util
 
                      , Test.Core.Lint

--- a/compiler/Test.hs
+++ b/compiler/Test.hs
@@ -1,12 +1,13 @@
 module Main where
 
-import Test.Tasty.Ingredients.ConsoleReporter
 import Test.Tasty.Ingredients.Basic
 import Test.Tasty.Runners.AntXML
 import Test.Tasty.Ingredients
 import Test.Tasty
 
 import Test.Util
+import Test.Reporter
+
 import qualified Test.Types.Unify as Solver
 import qualified Test.Core.Lint as Lint
 
@@ -33,4 +34,5 @@ tests = testGroup "Tests" <$> sequence
   ]
 
 main :: IO ()
-main = tests >>= defaultMainWithIngredients [ listingTests, consoleTestReporter `composeReporters` antXMLRunner ]
+main = tests >>= defaultMainWithIngredients [ listingTests
+                                            , boringReporter `composeReporters` antXMLRunner ]

--- a/compiler/Test/Reporter.hs
+++ b/compiler/Test/Reporter.hs
@@ -1,0 +1,161 @@
+{-# LANGUAGE OverloadedStrings, FlexibleContexts #-}
+module Test.Reporter (boringReporter) where
+
+import Control.Concurrent.STM
+import Control.Monad.Reader
+import Control.Monad.State
+
+import qualified Data.IntMap as IntMap
+import qualified Data.Text.IO as T
+import Data.Sequence (Seq)
+import Data.Foldable
+import Data.Monoid
+import Data.Proxy
+
+import Test.Tasty.Ingredients.ConsoleReporter (UseColor(..))
+import Test.Tasty.Ingredients
+import Test.Tasty.Providers
+import Test.Tasty.Runners hiding (Ap(..))
+import Test.Tasty.Options
+import Text.Printf
+
+import Text.Pretty.Ansi
+import Text.Pretty hiding (displayDecorated, putDoc)
+
+import Type.Reflection
+
+import System.IO
+
+data TestDisplay = Tests | Groups | None
+  deriving (Show, Eq, Typeable)
+
+instance IsOption TestDisplay where
+  defaultValue = None
+  parseValue "t" = Just Tests
+  parseValue "g" = Just Groups
+  parseValue "n" = Just None
+  parseValue _ = Nothing
+  optionName = "display"
+  optionHelp = "What information to output when running tests"
+
+newtype Timing = Timing Bool
+  deriving (Show, Eq, Typeable)
+
+instance IsOption Timing where
+  defaultValue = Timing False
+  parseValue = fmap Timing . safeReadBool
+  optionName = "timing"
+  optionHelp = "Show times to run tests"
+  optionCLParser = flagCLParser (Just 't') (Timing True)
+
+boringReporter :: Ingredient
+boringReporter
+  = TestReporter
+    [ Option (Proxy :: Proxy TestDisplay)
+    , Option (Proxy :: Proxy Timing)
+    , Option (Proxy :: Proxy UseColor)
+    ] run where
+  run options tree = Just (runReporter options tree)
+
+runReporter :: OptionSet -> TestTree -> StatusMap -> IO (Time -> IO Bool)
+runReporter options tree smap = do
+  -- Print a dot for each of the tests
+  hSetBuffering stdout NoBuffering
+  results <- printProgress smap mempty
+  putStrLn ""
+
+  -- And print a summary of the results
+  hSetBuffering stdout LineBuffering
+  printResults results
+
+  pure (const . pure $ foldr ((&&) . resultSuccessful) True results)
+
+  where
+    testDisplay = lookupOption options :: TestDisplay
+
+    printProgress :: StatusMap -> IntMap.IntMap Result -> IO (IntMap.IntMap Result)
+    printProgress tests results
+      | null tests = pure results
+      | otherwise = do
+          -- Wait for at least one new result
+          results' <- atomically $ do
+            done <- IntMap.mapMaybe getResult <$> traverse readTVar tests
+            if null done then retry
+            else pure done
+          traverse_ printProgressDot results'
+          printProgress (tests `IntMap.difference` results') (results `IntMap.union` results')
+
+    -- | Writes a progress dot to the terminal
+    printProgressDot r = T.hPutStr stdout . displayDecorated . renderPretty 0.4 100 $ case resultOutcome r of
+      Success -> annotate (DullColour Green) "•"
+      Failure TestFailed -> annotate (DullColour Red) "◼"
+      Failure _ -> annotate (DullColour Magenta) "✱"
+
+    printResults :: IntMap.IntMap Result -> IO ()
+    printResults results =
+      let res = flip evalState 0
+              . flip runReaderT 0
+              . getAp
+              $ foldTestTree (trivialFold { foldSingle = test, foldGroup = group })
+                             options tree
+      in putDoc (foldr (<##>) mempty (description res))
+
+      where
+        test :: (IsTest t, MonadState Int m)
+             => OptionSet -> TestName -> t -> Ap m Results
+        test _ test _ = Ap $ do
+          ~(Just result) <- gets (`IntMap.lookup` results)
+          modify (+1)
+          pure Results { totalTests = 1
+                       , successTests = if resultSuccessful result then 1 else 0
+                       , time = resultTime result
+                       , description = displayTest test result }
+
+        group name (Ap r) = Ap $ do
+          level <- ask
+          r' <- local (+1) r
+          pure (r' { description = displayGroup level name r' })
+
+    displayTest :: TestName -> Result -> Seq (Doc AnsiStyle)
+    displayTest name result
+      -- If we're not displaying tests and we passed, then skip this
+      | Tests /= testDisplay, Success <- resultOutcome result = mempty
+      | otherwise = pure
+        $ (case resultOutcome result of
+            Success -> annotate (DullColour Green) "✓"
+            Failure _ -> annotate (DullColour Red) "✘") <+> string name
+       <> (case resultDescription result of
+             "" -> mempty
+             l -> nest 2 (line <> string l))
+
+    displayGroup :: Int -> TestName -> Results -> Seq (Doc AnsiStyle)
+    displayGroup level name (Results total success time desc)
+      -- If we're displaying nothing, we've no children, and we're not
+      -- the root then display nothing.
+      | None <- testDisplay, null desc, level > 0 = mempty
+      | otherwise = pure
+        $ string name
+       <> (if time <= 0.01 then mempty else
+           annotate (DullColour Magenta) $ " took " <> string (printf "%.2fs" time))
+       <> (if total == 0 then mempty else
+           annotate (DullColour Cyan) $ " (" <> shown success <+> "out of" <+> shown total <+> "passed)")
+       <> nest 2 (foldMap (line<>) desc)
+
+data Results = Results
+  { totalTests :: Int
+  , successTests :: Int
+  , time :: Time
+  , description :: Seq (Doc AnsiStyle)
+  }
+
+instance Semigroup Results where
+  (Results t s ti d) <> (Results t' s' ti' d') = Results (t + t') (s + s') (ti + ti') (d <> d')
+
+instance Monoid Results where
+  mempty = Results 0 0 0 mempty
+
+
+-- | Extract the result from a status
+getResult :: Status -> Maybe Result
+getResult (Done r) = Just r
+getResult _ = Nothing


### PR DESCRIPTION
As the commit message says. Mostly inspired by every other test runner I've ever written:

 - Displays dots as the tests progress.
 - By default only shows failing tests/groups, though there are flags to make it more verbose (`--display t`, `--display g`).

Failures look like this:
![image](https://user-images.githubusercontent.com/4346137/50300522-9132eb80-047c-11e9-8010-9473a3a08290.png)

Successes look like this:
![image](https://user-images.githubusercontent.com/4346137/50300563-b0317d80-047c-11e9-9759-2a60605d64bb.png)

