### PR TITLE
Add flag to rerun tests

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -63,6 +63,7 @@ test-suite tests
                      , optparse-applicative >= 0.14 && < 0.15
   other-modules:       Test.Golden
                      , Test.Reporter
+                     , Test.Options
                      , Test.Rerun
                      , Test.Util
 

--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -53,12 +53,14 @@ test-suite tests
                      , tasty >= 1.0 && < 1.2
                      , these >= 0.7 && < 0.8
                      , amulet
+                     , filepath >= 1.4 && < 1.5
                      , hedgehog >= 0.5 && < 0.7
                      , directory >= 1.3 && < 1.4
                      , containers >= 0.5 && < 0.7
                      , tasty-hunit >= 0.10 && < 0.11
                      , tasty-ant-xml >= 1.1 && < 1.2
                      , tasty-hedgehog >= 0.2 && < 0.3
+                     , optparse-applicative >= 0.14 && < 0.15
   other-modules:       Test.Golden
                      , Test.Reporter
                      , Test.Rerun

--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -61,6 +61,7 @@ test-suite tests
                      , tasty-hedgehog >= 0.2 && < 0.3
   other-modules:       Test.Golden
                      , Test.Reporter
+                     , Test.Rerun
                      , Test.Util
 
                      , Test.Core.Lint

--- a/compiler/Test.hs
+++ b/compiler/Test.hs
@@ -5,8 +5,9 @@ import Test.Tasty.Runners.AntXML
 import Test.Tasty.Ingredients
 import Test.Tasty
 
-import Test.Util
 import Test.Reporter
+import Test.Rerun
+import Test.Util
 
 import qualified Test.Types.Unify as Solver
 import qualified Test.Core.Lint as Lint
@@ -34,5 +35,9 @@ tests = testGroup "Tests" <$> sequence
   ]
 
 main :: IO ()
-main = tests >>= defaultMainWithIngredients [ listingTests
-                                            , boringReporter `composeReporters` antXMLRunner ]
+main = tests >>= defaultMainWithIngredients ingredients where
+  ingredients =
+    [ rerunning
+      [ listingTests
+      , boringReporter `composeReporters` antXMLRunner ]
+    ]

--- a/compiler/Test/Options.hs
+++ b/compiler/Test/Options.hs
@@ -1,0 +1,24 @@
+module Test.Options
+  ( parsePrefix
+  ) where
+
+import qualified Data.Map as Map
+import Data.List
+
+data Prefixed a = Known String a | Ambiguous [String]
+
+type PrefixMap a = Map.Map String (Prefixed a)
+
+insertPrefixed :: String -> a -> PrefixMap a -> PrefixMap a
+insertPrefixed k v m = foldr (Map.alter (Just . go)) m (inits k) where
+  go Nothing = Known k v
+  go (Just (Known k' _)) = Ambiguous [k, k']
+  go (Just (Ambiguous ks)) = Ambiguous (k:ks)
+
+parsePrefix :: [(String, a)] -> String -> Maybe a
+parsePrefix os = maybePrefixed . flip Map.lookup prefixMap where
+  prefixMap = foldr (uncurry insertPrefixed) mempty os
+
+  maybePrefixed Nothing = Nothing
+  maybePrefixed (Just Ambiguous{}) = Nothing
+  maybePrefixed (Just (Known _ x)) = Just x

--- a/compiler/Test/Reporter.hs
+++ b/compiler/Test/Reporter.hs
@@ -30,22 +30,22 @@ data TestDisplay = Tests | Groups | None
   deriving (Show, Eq, Typeable)
 
 instance IsOption TestDisplay where
+  optionName = "display"
+  optionHelp = "What information to output when running tests"
   defaultValue = None
   parseValue "t" = Just Tests
   parseValue "g" = Just Groups
   parseValue "n" = Just None
   parseValue _ = Nothing
-  optionName = "display"
-  optionHelp = "What information to output when running tests"
 
 newtype Timing = Timing Bool
   deriving (Show, Eq, Typeable)
 
 instance IsOption Timing where
-  defaultValue = Timing False
-  parseValue = fmap Timing . safeReadBool
   optionName = "timing"
   optionHelp = "Show times to run tests"
+  defaultValue = Timing False
+  parseValue = fmap Timing . safeReadBool
   optionCLParser = flagCLParser (Just 't') (Timing True)
 
 boringReporter :: Ingredient

--- a/compiler/Test/Reporter.hs
+++ b/compiler/Test/Reporter.hs
@@ -17,6 +17,8 @@ import Test.Tasty.Ingredients
 import Test.Tasty.Providers
 import Test.Tasty.Runners hiding (Ap(..))
 import Test.Tasty.Options
+import Test.Options
+
 import Text.Printf
 
 import Text.Pretty.Ansi
@@ -33,10 +35,11 @@ instance IsOption TestDisplay where
   optionName = "display"
   optionHelp = "What information to output when running tests"
   defaultValue = None
-  parseValue "t" = Just Tests
-  parseValue "g" = Just Groups
-  parseValue "n" = Just None
-  parseValue _ = Nothing
+  parseValue = parsePrefix
+   [ ("tests", Tests)
+   , ("groups", Groups)
+   , ("none", None)
+   ]
 
 newtype Timing = Timing Bool
   deriving (Show, Eq, Typeable)

--- a/compiler/Test/Rerun.hs
+++ b/compiler/Test/Rerun.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE OverloadedStrings, FlexibleContexts, LambdaCase, TupleSections #-}
+module Test.Rerun (rerunning) where
+
+import Data.Foldable (asum)
+import Data.Maybe
+import Data.Monoid
+import Data.Proxy (Proxy(..))
+import Data.Typeable (Typeable)
+import System.IO.Error (catchIOError, isDoesNotExistError)
+import Text.Read
+
+import Control.Concurrent.STM
+
+import Control.Monad.State
+import Control.Monad.Reader
+import qualified Data.IntMap as IntMap
+import qualified Data.Map.Strict as Map
+
+import Test.Tasty.Options
+import Test.Tasty.Runners hiding (Ap(..))
+import Test.Tasty.Providers
+
+newtype RerunFile = RerunFile FilePath
+  deriving (Show, Eq, Typeable)
+
+instance IsOption RerunFile where
+  optionName = "rerun-file"
+  optionHelp = "The path to which the test runner's state should be saved"
+  defaultValue = RerunFile "dist-newstyle/.rerun"
+  parseValue = Just . RerunFile
+
+data PreserveLog = PreserveLog | UpdateLog
+  deriving (Show, Eq, Typeable)
+
+instance IsOption PreserveLog where
+  optionName = "rerun-preserve"
+  optionHelp = "Do not update the rerun state file for this run"
+  defaultValue = UpdateLog
+  parseValue "preserve" = Just PreserveLog
+  parseValue "update" = Just UpdateLog
+  parseValue _ = Nothing
+  optionCLParser = flagCLParser Nothing PreserveLog
+
+-- TODO: Potentially have a "repeat" version, which runs successful/failed tests, but not
+-- ones which didn't run previous times.
+data RerunFilter = RerunFailed | RerunAll
+  deriving (Show, Eq, Typeable)
+
+instance IsOption RerunFilter where
+  optionName = "rerun"
+  optionHelp = "Rerun all tests which are new or failed in the last run."
+  defaultValue = RerunAll
+  parseValue "all" = Just RerunAll
+  parseValue "failed" = Just RerunFailed
+  parseValue _ = Nothing
+  optionCLParser = flagCLParser (Just 'R') RerunFailed
+
+data TestResult = ResultOk | ResultErr | ResultNew
+  deriving (Read, Show)
+
+type RerunState = Map.Map [TestName] TestResult
+
+-- | Determine if the 'TestResult' matches the current 'RerunFilter'
+resultMatches :: RerunFilter -> TestResult -> Bool
+resultMatches RerunAll _ = True
+resultMatches RerunFailed ResultOk = False
+resultMatches RerunFailed ResultNew = False
+resultMatches RerunFailed ResultErr = True
+
+-- | Allows rerunning the tests. One should wrap all other ingredients with this one.
+rerunning :: [Ingredient] -> Ingredient
+rerunning ingredients =
+  TestManager
+  ([ Option (Proxy :: Proxy RerunFile)
+   , Option (Proxy :: Proxy PreserveLog)
+   , Option (Proxy :: Proxy RerunFilter)
+   ] ++ existingOptions) (doRerun ingredients) where
+
+  existingOptions = flip concatMap ingredients $ \case
+      TestReporter options _ -> options
+      TestManager options _ -> options
+
+doRerun :: [Ingredient] -> OptionSet -> TestTree -> Maybe (IO Bool)
+doRerun ingredients options testTree = Just $ do
+  oldState <- loadState
+
+  let
+      filteredTestTree = maybe id (filterTestTree . filterMatches) oldState testTree
+
+      tryIngredientMonitored :: Ingredient -> Maybe (IO Bool)
+      tryIngredientMonitored (TestReporter _ f) = do
+        runner <- f options filteredTestTree
+        pure $ do
+          (status, outcome) <- launchTestTree options filteredTestTree $ \sMap ->
+              do f' <- runner sMap
+                 pure (fmap (sMap,) . f')
+
+          when (preserve == UpdateLog) $ do
+            results <- getResults status
+            let newState = extractState results filteredTestTree
+            -- TODO: Should we merge with the old state here? We could potentially
+            -- partition the test tree, and add back all elements which didn't match our
+            -- filter.
+            saveState newState
+
+          pure outcome
+
+      -- We can't actually monitor the tests in this case.
+      -- TODO: Warn?
+      tryIngredientMonitored (TestManager _ f) = f options filteredTestTree
+
+  -- If nobody ran the tests then ideally we'd return Nothing. However, we needed IO in
+  -- order to read the previous state, so let's pretend we're all good.
+  fromMaybe (pure True) (asum (map tryIngredientMonitored ingredients))
+
+  where
+    RerunFile stateFile = lookupOption options
+    preserve = lookupOption options :: PreserveLog
+    filter = lookupOption options :: RerunFilter
+
+    -- | Determine if the provided test name matches the provided filter.
+    filterMatches state name = resultMatches filter . fromMaybe ResultNew $ Map.lookup name state
+
+    -- | Load the state from a file
+    loadState :: IO (Maybe RerunState)
+    loadState =
+      (readMaybe <$> readFile stateFile)
+      `catchIOError` (\e -> if isDoesNotExistError e then pure Nothing else ioError e)
+
+    -- | Save the state to a file
+    saveState :: RerunState -> IO ()
+    saveState results = do
+      -- createDirectoryIfMissing True path -- TODO: Get parent directory - we'll require filepath's splitFileName
+      writeFile stateFile (show results)
+
+    -- | Get all results for the given 'StatusMap'
+    getResults :: StatusMap -> IO (IntMap.IntMap TestResult)
+    getResults tests = atomically $ IntMap.map getResult <$> traverse readTVar tests
+
+    getResult :: Status -> TestResult
+    getResult (Done (Result Success _ _ _)) = ResultOk
+    getResult (Done (Result Failure{} _ _ _)) = ResultErr
+    getResult _ = error "Test should have been run"
+
+    -- | Extract the 'RerunState' from the filtered test tree + extracted results.
+    extractState :: IntMap.IntMap TestResult -> TestTree -> RerunState
+    extractState results tree
+      = flip evalState 0
+      . flip runReaderT []
+      . getAp
+      $ foldTestTree (trivialFold { foldSingle = test, foldGroup = group }) options tree
+      where
+        test _ name _ = Ap $ do
+          ~(Just result) <- gets (`IntMap.lookup` results)
+          modify (+1)
+          suf <- ask
+          pure (Map.singleton (name:suf) result)
+
+        group name (Ap r) = Ap $ local (name:) r
+
+
+-- | Filters a test tree which matches a predicate.
+filterTestTree :: ([TestName] -> Bool) -> TestTree -> TestTree
+filterTestTree f = go' [] where
+  go' x = fromMaybe (TestGroup "" []) . go x
+
+  go :: [TestName] -> TestTree -> Maybe TestTree
+  go suf t@(SingleTest name _) = if f (name:suf) then Just t else Nothing
+  go suf (TestGroup name tests) =
+    case mapMaybe (go (name:suf)) tests of
+      [] -> Nothing
+      tests' -> Just (TestGroup name tests')
+  go suf (PlusTestOptions f t) = PlusTestOptions f <$> go suf t
+
+  go suf (WithResource rSpec f) = Just (WithResource rSpec (go' suf <$> f))
+  go suf (AskOptions f) = Just (AskOptions (go' suf <$> f))

--- a/compiler/Test/Rerun.hs
+++ b/compiler/Test/Rerun.hs
@@ -19,6 +19,7 @@ import System.Directory
 import Test.Tasty.Options
 import Test.Tasty.Runners hiding (Ap(..))
 import Test.Tasty.Providers
+import Test.Options
 
 import Text.Read
 
@@ -40,9 +41,9 @@ instance IsOption PreserveLog where
   optionName = "rerun-preserve"
   optionHelp = "Do not update the rerun state file for this run"
   defaultValue = UpdateLog
-  parseValue "preserve" = Just PreserveLog
-  parseValue "update" = Just UpdateLog
-  parseValue _ = Nothing
+  parseValue = parsePrefix
+    [ ("preserve", PreserveLog)
+    , ("update", UpdateLog) ]
   optionCLParser = flagCLParser Nothing PreserveLog
 
 data RerunFilter
@@ -55,10 +56,11 @@ instance IsOption RerunFilter where
   optionName = "rerun"
   optionHelp = "Rerun all tests which are new or failed in the last run."
   defaultValue = RerunAll
-  parseValue "all" = Just RerunAll
-  parseValue "failed" = Just RerunFailed
-  parseValue "same" = Just RerunFailed
-  parseValue _ = Nothing
+  parseValue = parsePrefix
+    [ ("all", RerunAll)
+    , ("failed", RerunFailed)
+    , ("same", RerunSame)
+    ]
   optionCLParser = flagCLParser (Just 'R') RerunFailed
 
 data TestResult = ResultOk | ResultErr | ResultNotRun

--- a/compiler/Test/Rerun.hs
+++ b/compiler/Test/Rerun.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverloadedStrings, FlexibleContexts, LambdaCase, TupleSections #-}
+{-# LANGUAGE OverloadedStrings, FlexibleContexts, TupleSections #-}
 module Test.Rerun (rerunning) where
 
 import Control.Concurrent.STM

--- a/default.nix
+++ b/default.nix
@@ -48,6 +48,7 @@ let
       , HUnit
       , tasty
       , these
+      , filepath
       , hashable
       , hedgehog
       , directory
@@ -87,7 +88,7 @@ let
         ];
 
         testHaskellDepends = [
-          base bytestring Diff directory hedgehog HUnit lens mtl
+          base bytestring Diff directory filepath hedgehog HUnit lens mtl
           pretty-show tasty tasty-hedgehog tasty-hunit text
           tasty-ant-xml
         ];


### PR DESCRIPTION
![Screenshot of it in action](https://user-images.githubusercontent.com/4346137/50963799-9dcbc200-14c5-11e9-95ba-77df7c019e76.png)

This simply writes the result of the last test execution to `dist-newstyle/.rerun`. Passing `-R` will cause only the failing tests to be re-executed.
