### PR TITLE
Add an explicit syntax for empty variants

### DIFF
--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -330,7 +330,9 @@ lowerProg' (LetStmt _ vs:prg) = do
     vs' <- lowerLet vs
     foldr ((.) . ((:) . C.StmtLet)) id vs' <$$> lowerProg' prg
 
-lowerProg' (TypeDecl _ var _ cons:prg) = do
+lowerProg' (TypeDecl _ var _ Nothing _:prg) = do
+  (C.Type (mkType var) []:) <$$> lowerProg' prg
+lowerProg' (TypeDecl _ var _ (Just cons) _:prg) = do
   let cons' = map (\case
                        UnitCon _ p (_, t) -> (p, mkCon p, lowerType t)
                        ArgCon _ p _ (_, t) -> (p, mkCon p, lowerType t)

--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -330,7 +330,7 @@ lowerProg' (LetStmt _ vs:prg) = do
     vs' <- lowerLet vs
     foldr ((.) . ((:) . C.StmtLet)) id vs' <$$> lowerProg' prg
 
-lowerProg' (TypeDecl _ var _ Nothing _:prg) = do
+lowerProg' (TypeDecl _ var _ Nothing _:prg) =
   (C.Type (mkType var) []:) <$$> lowerProg' prg
 lowerProg' (TypeDecl _ var _ (Just cons) _:prg) = do
   let cons' = map (\case

--- a/src/Core/Lower/Basic.hs
+++ b/src/Core/Lower/Basic.hs
@@ -28,6 +28,7 @@ data LowerState
   = LS
     { vars  :: VarMap.Map (C.Type CoVar)
     , ctors :: VarMap.Map (C.Type CoVar)
+    -- | The map of types to their constructors /if they have any/.
     , types :: VarMap.Map VarSet.Set
     } deriving (Eq, Show)
 

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -177,8 +177,8 @@ Top :: { Toplevel Parsed }
     | external Access val BindName ':' Type '=' string
       { withPos2 $1 $8 $ ForeignVal $2 (getL $4) (getString $8) (getL $6) }
 
-    | Access type BindName ListE(TyConArg) TypeBody { TypeDecl $1 (getL $3) $4 $5 }
-    | Access type TyConArg BindOp TyConArg TypeBody { TypeDecl $1 (getL $4) [$3, $5] $6 }
+    | Access type BindName ListE(TyConArg) TypeBody { withPos2 $2 $3 $ TypeDecl $1 (getL $3) $4 $5 }
+    | Access type TyConArg BindOp TyConArg TypeBody { withPos2 $2 $4 $ TypeDecl $1 (getL $4) [$3, $5] $6 }
 
     | module qconid '=' Begin(Tops)            { Module Public (getName $2) (getL $4) }
     | private module qconid '=' Begin(Tops)    { Module Private (getName $3) (getL $5) }
@@ -197,10 +197,11 @@ Begin(a)
   : begin a end                             { lPos2 $1 $3 $2 }
   | '$begin' a '$end'                       { lPos2 $1 $3 $2 }
 
-TypeBody :: { [Constructor Parsed] }
-  :                                            { [] }
-  | '=' List1(Ctor, '|')                       { $2 }
-  | '=' '|' List1(Ctor, '|')                   { $3 }
+TypeBody :: { Maybe [Constructor Parsed] }
+  :                                            { Nothing }
+  | '=' List1(Ctor, '|')                       { Just $2 }
+  | '=' '|' List1(Ctor, '|')                   { Just $3 }
+  | '=' '|'                                    { Just [] }
 
 ClassItems :: { [ClassItem Parsed] }
   : List(ClassItem, TopSep) { $1 }

--- a/src/Syntax/Desugar.hs
+++ b/src/Syntax/Desugar.hs
@@ -27,7 +27,7 @@ import Syntax
 
 -- | Desugar a program into a more simple representation
 desugarProgram :: forall m. MonadNamey m => [Toplevel Resolved] -> m [Toplevel Desugared]
-desugarProgram = traverse statement 
+desugarProgram = traverse statement
 
 statement :: forall m. MonadNamey m => Toplevel Resolved -> m (Toplevel Desugared)
 statement (LetStmt am vs) = LetStmt am <$> traverse binding vs
@@ -36,7 +36,7 @@ statement (Instance a b c m d) = Instance a (ty <$> b) (ty c) <$> traverse bindi
 statement (Class am a b c m d) = Class am a (ty <$> b) (tyA <$> c) <$> traverse classItem m <*> pure d
 statement (Open v a) = pure $ Open v a
 statement (ForeignVal am v x t a) = pure $ ForeignVal am v x (ty t) a
-statement (TypeDecl am v arg cs) = pure $ TypeDecl am v (map tyA arg) (map ctor cs)
+statement (TypeDecl am v arg cs a) = pure $ TypeDecl am v (map tyA arg) (map ctor <$> cs) a
 
 classItem :: forall m. MonadNamey m => ClassItem Resolved -> m (ClassItem Desugared)
 classItem (MethodSig v t a) = pure $ MethodSig v (ty t) a
@@ -242,7 +242,7 @@ transDoExpr bind = go where
     pure $ BinOp e bind cont an
   go (CompLet bg an:qs) = Let <$> traverse binding bg <*> go qs <*> pure an
   go [CompGuard e] = expr e
-  go (CompGuard e:qs) = 
+  go (CompGuard e:qs) =
     let begin a b = Begin [ a, b ]
      in begin <$> expr e <*> go qs <*> pure (annotation e)
   go [] = undefined

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -109,7 +109,7 @@ resolveModule (d@(TypeDecl am t vs cs ann):rs) = do
   c' <- traverse tagVar c
   extendTy (t, t') $ extendN (zip c c') $ do
     body <- TypeDecl am t' vs'
-      <$> (maybe (pure Nothing) (fmap Just . traverse (resolveCons sc) . zip c') cs)
+      <$> maybe (pure Nothing) (fmap Just . traverse (resolveCons sc) . zip c') cs
       <*> pure ann
     (body:) <$> resolveModule rs
 

--- a/src/Syntax/Resolve/Toplevel.hs
+++ b/src/Syntax/Resolve/Toplevel.hs
@@ -25,7 +25,7 @@ extractToplevel (LetStmt Public d) = (foldMap bindVariables d, [])
 extractToplevel (LetStmt Private _) = mempty
 extractToplevel (ForeignVal Public v _ _ _) = ([v], [])
 extractToplevel (ForeignVal Private _ _ _ _) = mempty
-extractToplevel (TypeDecl Public v _ c) = (mapMaybe ctor c, [v]) where
+extractToplevel (TypeDecl Public v _ c _) = (maybe [] (mapMaybe ctor) c, [v]) where
   ctor (UnitCon a v _) = access a v
   ctor (ArgCon a v _ _) = access a v
   ctor (GadtCon a v _ _) = access a v
@@ -33,7 +33,7 @@ extractToplevel (TypeDecl Public v _ c) = (mapMaybe ctor c, [v]) where
   access Public = Just
   access _ = const Nothing
 
-extractToplevel (TypeDecl Private _ _ _) = mempty
+extractToplevel (TypeDecl Private _ _ _ _) = mempty
 extractToplevel (Open _ _) = mempty
 extractToplevel (Module Public v xs) =
   let (vs, ts) = extractToplevels xs

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -389,7 +389,7 @@ inferProg (decl@(TypeDecl am n tvs cs ann):prg) = do
         consFst (TypeDecl am n tvs cs (ann, undefined)) $
           inferProg prg
 
-  local (names %~ focus (one n (fst (rename kind)))) $ do
+  local (names %~ focus (one n (fst (rename kind)))) $
     case cs of
       Nothing -> cont Nothing
       Just cs -> do

--- a/src/Types/Infer.hs
+++ b/src/Types/Infer.hs
@@ -373,9 +373,9 @@ inferProg (st@(ForeignVal am v d t ann):prg) = do
     consFst (ForeignVal am v d t' (ann, t')) $
       inferProg prg
 
-inferProg (decl@(TypeDecl am n tvs cs):prg) = do
+inferProg (decl@(TypeDecl am n tvs cs ann):prg) = do
   (kind, retTy, tvs) <- retcons (addBlame (BecauseOf decl)) $
-                          resolveTyDeclKind (BecauseOf decl) n tvs cs
+                          resolveTyDeclKind (BecauseOf decl) n tvs (fromMaybe [] cs)
   let scope (TyAnnArg v k:vs) = one v k <> scope vs
       scope (_:cs) = scope cs
       scope [] = mempty
@@ -385,16 +385,22 @@ inferProg (decl@(TypeDecl am n tvs cs):prg) = do
           TyVarArg v -> Set.singleton v
           TyAnnArg v _ -> Set.singleton v
 
-  local (names %~ focus (one n (fst (rename kind)))) $ do
-    (ts, cs') <- unzip <$> local (names %~ focus (scope tvs))
-      (for cs (\con -> retcons (addBlame (BecauseOf con)) (inferCon vars retTy con)))
-    let ts' = Set.fromList (map fst ts)
-
-    local ( (names %~ focus (teleFromList ts))
-          . (types %~ Map.insert n ts')
-          . (constructors %~ Set.union ts') ) $
-        consFst (TypeDecl am n tvs cs') $
+  let cont cs =
+        consFst (TypeDecl am n tvs cs (ann, undefined)) $
           inferProg prg
+
+  local (names %~ focus (one n (fst (rename kind)))) $ do
+    case cs of
+      Nothing -> cont Nothing
+      Just cs -> do
+        (ts, cs') <- unzip <$> local (names %~ focus (scope tvs))
+          (for cs (\con -> retcons (addBlame (BecauseOf con)) (inferCon vars retTy con)))
+
+        let ts' = Set.fromList (map fst ts)
+        local ( (names %~ focus (teleFromList ts))
+                . (types %~ Map.insert n ts')
+                . (constructors %~ Set.union ts') ) $
+          cont (Just cs')
 
 inferProg (Open mod pre:prg) = do
   modImplicits <- view (modules . at mod . non undefined)

--- a/src/Types/Infer/Class.hs
+++ b/src/Types/Infer/Class.hs
@@ -156,8 +156,8 @@ inferClass clss@(Class name _ ctx _ methods classAnn) = do
 
     let tyDecl :: Toplevel Typed
         tyDecl = TypeDecl Public name params
-          [ ArgCon Private classCon inner (classAnn, classConTy)
-          ]
+          (Just [ArgCon Private classCon inner (classAnn, classConTy)])
+          (classAnn, undefined)
 
     let mkDecl :: (Type Typed -> TyBinder Typed, Var Typed, T.Text, Type Typed) -> m (Binding Typed)
         mkDecl (f, var, label, theTy) = do

--- a/tests/types/gadt/gadt01.out
+++ b/tests/types/gadt/gadt01.out
@@ -1,7 +1,7 @@
-gadt01.ml[3:16 ..3:23]: error
+gadt01.ml[3:1 ..3:23]: error
   │ 
 3 │ type gadt 'a = R : gadt
-  │                ^^^^^^^^
+  │ ^^^^^^^^^^^^^^^^^^^^^^^
   Couldn't match actual type 'd -> type
     with the type expected by the context, type
 

--- a/tests/verify/pmcheck/empty_match_01.ml
+++ b/tests/verify/pmcheck/empty_match_01.ml
@@ -5,10 +5,10 @@ let f1 : forall 'a. int -> 'a =
 type foo = A | B
 
 (* non-exhaustive *)
-let f2 (x : foo) = 
+let f2 (x : foo) =
   match x with ()
 
 (* exhaustive *)
-type void
+type void = |
 let f3 (x : void) =
   match x with ()

--- a/tests/verify/pmcheck/empty_match_01.out
+++ b/tests/verify/pmcheck/empty_match_01.out
@@ -12,10 +12,3 @@ empty_match_01.ml[9:3 ..9:14]: warning
   │   ^^^^^^^^^^^^
   • Note: The following patterns are not covered
       _
-empty_match_01.ml[14:3 ..14:14]: warning
-  Non-exhaustive patterns in expression
-   │ 
-14 │   match x with ()
-   │   ^^^^^^^^^^^^
-  • Note: The following patterns are not covered
-      _

--- a/tests/verify/pmcheck/empty_match_02.ml
+++ b/tests/verify/pmcheck/empty_match_02.ml
@@ -1,4 +1,4 @@
-type a = A of a
+type a = |
 type b = B1 | B2
 
 type c 'a =

--- a/tests/verify/pmcheck/empty_match_02.out
+++ b/tests/verify/pmcheck/empty_match_02.out
@@ -1,10 +1,3 @@
-empty_match_02.ml[17:3 ..17:14]: warning
-  Non-exhaustive patterns in expression
-   │ 
-17 │   match x with ()
-   │   ^^^^^^^^^^^^
-  • Note: The following patterns are not covered
-      _
 empty_match_02.ml[21:3 ..21:14]: warning
   Non-exhaustive patterns in expression
    │ 


### PR DESCRIPTION
This allows us to distinguish abstract types from concrete ones with no inhabitants:

```ml
    type abstract
    type void = |
```

We also update the totality checker to handle this, meaning we can finally fix several false-positives.