### PR TITLE
Preserve term ordering invariants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ src/**/*.info
 
 !/tests/lua/*.lua
 !/tests/lua_parse/*.lua
+!/tests/lua_no_opt/*.lua
 
 cabal.project.local*
 .ghc*

--- a/compiler/Test/Core/Backend.hs
+++ b/compiler/Test/Core/Backend.hs
@@ -3,10 +3,13 @@ module Test.Core.Backend (tests) where
 import Test.Tasty
 import Test.Util
 
+import Control.Monad.State
 import Control.Monad.Infer
 
 import qualified Data.Text.Lazy as L
 import qualified Data.Text as T
+import Data.Foldable
+import Data.Triple
 
 import Parser.Wrapper (runParser)
 import Parser
@@ -17,23 +20,52 @@ import Syntax.Resolve (resolveProgram)
 import Syntax.Desugar (desugarProgram)
 import Syntax.Builtin
 
+import Core.Occurrence
 import Core.Simplify
 import Core.Lower
+import Core.Var
+import Core.Core
 
+import Language.Lua.Syntax
+import Backend.Lua.Postprocess
+import Backend.Lua.Emit
 import Backend.Lua
 
 import Text.Pretty.Semantic
 
-result :: String -> T.Text -> T.Text
-result f c = fst . flip runNamey firstName $ do
+result :: Bool -> String -> T.Text -> T.Text
+result o f c = fst . flip runNamey firstName $ do
   let parsed = requireJust f c $ runParser f (L.fromStrict c) parseTops
   (resolved, _) <- requireRight f c <$> resolveProgram builtinResolve builtinModules parsed
   desugared <- desugarProgram resolved
   (inferred, _) <- requireThat f c <$> inferProgram builtinEnv desugared
   lower <- runLowerT (lowerProg inferred)
-  optm <- optimise lower
+  compiled <-
+    if o
+    then compileProgram <$> optimise lower
+    else pure . LuaDo . toList . fst
+       . uncurry addBuiltins
+       . flip runState defaultEmitState . emitStmt
+       . patchupUsage . snd . tagOccurStmt (const occursSet) OccursVar
+       $ lower
   pure . display . uncommentDoc . renderPretty 0.8 120 . (<##>empty)
-       . pretty . compileProgram $ optm
+       $ pretty compiled
 
 tests :: IO TestTree
-tests = testGroup "Tests.Core.Backend" <$> goldenDirOn result (++".lua") "tests/lua/" ".ml"
+tests = do
+  withOpt <- goldenDirOn (result True) (++".lua") "tests/lua/" ".ml"
+  noOpt <- goldenDirOn (result False) (++".lua") "tests/lua_no_opt/" ".ml"
+  pure $ testGroup "Tests.Core.Backend"
+    [ testGroup "No optimiser" noOpt
+    , testGroup "With optimiser" withOpt
+    ]
+
+patchupUsage :: IsVar a => [AnnStmt b (OccursVar a)] -> [AnnStmt b(OccursVar a)]
+patchupUsage [] = []
+patchupUsage (s@Foreign{}:xs) = s:patchupUsage xs
+patchupUsage (s@Type{}:xs) = s:patchupUsage xs
+patchupUsage (StmtLet (One v):xs) = StmtLet (One (first3 patchupVarUsage v)):patchupUsage xs
+patchupUsage (StmtLet (Many v):xs) = StmtLet (Many (map (first3 patchupVarUsage) v)):patchupUsage xs
+
+patchupVarUsage :: OccursVar a -> OccursVar a
+patchupVarUsage (OccursVar v u) = OccursVar v (u <> Once)

--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -594,8 +594,11 @@ withinTerm var term m = do
   ari <- view emitArity
   prev <- use emitPrev
 
+  -- We add the previous term as a dependency if we're impure (obviously), or if
+  -- we're the last term in a block. Yes, this is an ugly hack - ideally it'd be
+  -- done in emitTerm.
   let p = isPure ari term
-      deps = extractAnn term <> (if p then mempty else prev)
+      deps = extractAnn term <> (if not p || toVar var == vReturn then prev else mempty)
   (deps', binds, result) <- runNES deps m
 
   -- Update the pure set if needed

--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE
   OverloadedStrings, NamedFieldPuns, FlexibleContexts
-, TupleSections, ViewPatterns, ScopedTypeVariables
-, TemplateHaskell, QuasiQuotes #-}
+, FlexibleInstances, TupleSections, ViewPatterns
+, ScopedTypeVariables, TemplateHaskell, QuasiQuotes #-}
 module Backend.Lua.Emit
   ( emitStmt
   , TopEmitState(..), topVars, topArity, topEscape, topExVars
@@ -41,7 +41,6 @@ import Backend.Escape
 
 import Text.Dot
 import Text.Pretty.Semantic
-import Debug.Trace
 
 -- | A magic variable used to represent the return value
 vReturn :: CoVar
@@ -165,6 +164,12 @@ toGraph = Graph DirectedGraph
     genNode (EmittedExpr expr _ _ _) = vsep . map pretty $ expr
     genNode (EmittedStmt stmt _ _ _) = vsep . map pretty . toList $ stmt
     genNode EmittedUpvalue{} = "Upvalue"
+
+instance IsVar a => Pretty (VarMap.Map (EmittedNode a)) where
+  pretty = drawGraph disp . toGraph where
+    disp (CoVar id name _) = text name <> "_" <> int' id
+    int' x | x < 0 = "_" <> int (-x)
+           | otherwise = int x
 
 -- | The default (initial) state for the emitter.
 defaultEmitState :: TopEmitState

--- a/src/Text/Pretty.hs
+++ b/src/Text/Pretty.hs
@@ -19,6 +19,8 @@ import qualified Data.Text.Lazy.Builder as B
 import qualified Data.Text.Lazy as L
 import qualified Data.Text as T
 
+import Text.Show.Pretty (ppShow)
+
 import qualified Text.PrettyPrint.Annotated.Leijen as P
 import Text.PrettyPrint.Annotated.Leijen hiding (text, display, (<>), (<$>), (<$$>))
 
@@ -45,7 +47,7 @@ text = string . T.unpack
 
 -- | Build a document from some 'show'able value.
 shown :: Show b => b -> Doc a
-shown = string . show
+shown = string . ppShow
 
 -- | Prepend a bullet to a document.
 bullet :: Doc a -> Doc a

--- a/tests/lua_no_opt/function-order-01.lua
+++ b/tests/lua_no_opt/function-order-01.lua
@@ -1,0 +1,10 @@
+do
+  local file_close = io.close
+  local file_read = io.read
+  local print = print
+  local function file_load(fhandle)
+    file_read("*all")
+    file_close(fhandle)
+    return nil
+  end
+end

--- a/tests/lua_no_opt/function-order-01.ml
+++ b/tests/lua_no_opt/function-order-01.ml
@@ -1,0 +1,11 @@
+type file
+
+external val file_close : file -> () = "io.close"
+external val file_read : string -> string = "io.read"
+external val print : string -> unit = "print"
+
+let file_load fhandle =
+  let output = file_read "*all"
+  file_close fhandle
+  let x = output
+  ()

--- a/tests/lua_no_opt/function-order-02.lua
+++ b/tests/lua_no_opt/function-order-02.lua
@@ -1,0 +1,10 @@
+do
+  local file_close = io.close
+  local file_read = io.read
+  local print = print
+  local function file_load(fhandle)
+    local output = file_read("*all")
+    file_close(fhandle)
+    return output
+  end
+end

--- a/tests/lua_no_opt/function-order-02.ml
+++ b/tests/lua_no_opt/function-order-02.ml
@@ -1,0 +1,10 @@
+type file
+
+external val file_close : file -> () = "io.close"
+external val file_read : string -> string = "io.read"
+external val print : string -> unit = "print"
+
+let file_load fhandle =
+  let output = file_read "*all"
+  file_close fhandle
+  output


### PR DESCRIPTION
Will fix #163 at some point, currently only fixes on of the edge cases.

The current issue here is that impure nodes may get merged into pure ones. As a result, we break the ordering invariant, as any dependencies on this impure node are dropped.

This attempts to fix this, by introducing a "consumed" node, which simply says "we've been merged into another node", and so any dependencies on the merged node, now depend on the parent.

There's still two test cases which are not functioning quite how they should:
 - `stream.lua` - the introduction of the consumed node now means that the loop has a graph.
 - `function-order-02.lua` - this is the bug mentioned in #163. I haven't introduced any logic for this yet - I'm not 100% sure how to fix this properly yet, though have some ideas.

```diff
diff --git a/tests/lua/stream.lua b/tests/lua/stream.lua
index afb5884..0113096 100644
--- a/tests/lua/stream.lua
+++ b/tests/lua/stream.lua
@@ -8,7 +8,8 @@ do
         return print("]")
     end
     io_write("'" .. to_string(st) .. "', ")
-    return go(st + 1)
+    local ok = st + 1
+    return go(ok)
   end
   local main = go(1)
   (nil)(main)
diff --git a/tests/lua_no_opt/function-order-02.lua b/tests/lua_no_opt/function-order-02.lua
index 052d8a4..2553f77 100644
--- a/tests/lua_no_opt/function-order-02.lua
+++ b/tests/lua_no_opt/function-order-02.lua
@@ -3,8 +3,7 @@ do
   local file_read = io.read
   local print = print
   local function file_load(fhandle)
-    local output = file_read("*all")
     file_close(fhandle)
-    return output
+    return file_read("*all")
   end
 end
```