### PR TITLE
Add type synonyms

### DIFF
--- a/compiler/Test/Types/Check.hs
+++ b/compiler/Test/Types/Check.hs
@@ -55,4 +55,5 @@ tests = do
   wild <- testGroup "Type wildcard tests" <$> goldenDir result "tests/types/wildcards/" ".ml"
   clss <- testGroup "Type class tests" <$> goldenDir result "tests/types/class/" ".ml"
   vta <- testGroup "Visible type application tests" <$> goldenDir result "tests/types/vta/" ".ml"
-  pure (testGroup "Type inference" [ inference, gadts, rankn, lazy, letgen, wild, clss, vta ])
+  syn <- testGroup "Type synonym tests " <$> goldenDir result "tests/types/synonym/" ".ml"
+  pure (testGroup "Type inference" [ inference, gadts, rankn, lazy, letgen, wild, clss, vta, syn ])

--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -297,6 +297,7 @@ lowerProg' (Open _ _:prg) = lowerProg' prg
 lowerProg' (Module _ _ b:prg) = lowerProg' (b ++ prg)
 lowerProg' (Class{}:prg) = lowerProg' prg
 lowerProg' (Instance{}:prg) = lowerProg' prg
+lowerProg' (TySymDecl{}:prg) = lowerProg' prg
 
 lowerProg' (ForeignVal _ v ex tp _:prg) =
   let tyB = lowerType tp

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -180,6 +180,11 @@ Top :: { Toplevel Parsed }
     | Access type BindName ListE(TyConArg) TypeBody { withPos2 $2 $3 $ TypeDecl $1 (getL $3) $4 $5 }
     | Access type TyConArg BindOp TyConArg TypeBody { withPos2 $2 $4 $ TypeDecl $1 (getL $4) [$3, $5] $6 }
 
+    | Access type BindName ListE(TyConArg) '<-' Type
+        { withPos2 $2 $3 $ TySymDecl $1 (getL $3) $4 (getL $6) }
+    | Access type TyConArg BindOp TyConArg '<-' Type
+        { withPos2 $2 $4 $ TySymDecl $1 (getL $4) [$3, $5] (getL $7) }
+
     | module qconid '=' Begin(Tops)            { Module Public (getName $2) (getL $4) }
     | private module qconid '=' Begin(Tops)    { Module Private (getName $3) (getL $5) }
     | module conid '=' Begin(Tops)             { Module Public (getName $2) (getL $4) }

--- a/src/Syntax/Desugar.hs
+++ b/src/Syntax/Desugar.hs
@@ -37,6 +37,7 @@ statement (Class am a b c m d) = Class am a (ty <$> b) (tyA <$> c) <$> traverse 
 statement (Open v a) = pure $ Open v a
 statement (ForeignVal am v x t a) = pure $ ForeignVal am v x (ty t) a
 statement (TypeDecl am v arg cs a) = pure $ TypeDecl am v (map tyA arg) (map ctor <$> cs) a
+statement (TySymDecl am v arg exp a) = pure $ TySymDecl am v (map tyA arg) (ty exp) a
 
 classItem :: forall m. MonadNamey m => ClassItem Resolved -> m (ClassItem Desugared)
 classItem (MethodSig v t a) = pure $ MethodSig v (ty t) a

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -102,6 +102,15 @@ resolveModule (r@(ForeignVal am v t ty a):rs) = do
     <*> resolveModule rs
 
   where wrap x = foldr (TyPi . flip (flip Invisible Nothing) Spec) x (toList (ftv x))
+
+resolveModule (d@(TySymDecl am t vs ty ann):rs) = do
+  t' <- tagVar t
+  (vs', sc) <- resolveTele d vs
+  extendTyvarN sc $ do
+    decl <- TySymDecl am t' vs' <$> reType d ty <*> pure ann
+    extendTy (t, t') $
+      (decl:) <$> resolveModule rs
+
 resolveModule (d@(TypeDecl am t vs cs ann):rs) = do
   t'  <- tagVar t
   (vs', sc) <- resolveTele d vs

--- a/src/Syntax/Resolve/Toplevel.hs
+++ b/src/Syntax/Resolve/Toplevel.hs
@@ -34,6 +34,10 @@ extractToplevel (TypeDecl Public v _ c _) = (maybe [] (mapMaybe ctor) c, [v]) wh
   access _ = const Nothing
 
 extractToplevel (TypeDecl Private _ _ _ _) = mempty
+
+extractToplevel (TySymDecl Private _ _ _ _) = mempty
+extractToplevel (TySymDecl Public v _ _ _) = (mempty, [v])
+
 extractToplevel (Open _ _) = mempty
 extractToplevel (Module Public v xs) =
   let (vs, ts) = extractToplevels xs

--- a/src/Syntax/Toplevel.hs
+++ b/src/Syntax/Toplevel.hs
@@ -30,6 +30,7 @@ data Toplevel p
   = LetStmt TopAccess [Binding p]
   | ForeignVal TopAccess (Var p) Text (Type p) (Ann p)
   | TypeDecl TopAccess (Var p) [TyConArg p] (Maybe [Constructor p]) (Ann p)
+  | TySymDecl TopAccess (Var p) [TyConArg p] (Type p) (Ann p)
   | Module TopAccess (Var p) [Toplevel p]
   | Open { openName :: Var p
          , openAs :: Maybe Text }
@@ -107,7 +108,7 @@ prettyAcc :: TopAccess -> Doc
 prettyAcc Public = empty
 prettyAcc x = pretty x <+> empty
 
-instance (Pretty (Var p)) => Pretty (Toplevel p) where
+instance Pretty (Var p) => Pretty (Toplevel p) where
   pretty (LetStmt _ []) = string "empty let?"
   pretty (LetStmt m (x:xs)) =
     let prettyBind x = keyword "and" <+> pretty x
@@ -125,6 +126,9 @@ instance (Pretty (Var p)) => Pretty (Toplevel p) where
     in keyword "type" <+> prettyAcc m <> pretty ty <+> hsep (map ((squote <>) . pretty) args) <+> ct
   pretty (Open m Nothing) = keyword "open" <+> pretty m
   pretty (Open m (Just a)) = keyword "open" <+> pretty m <+> keyword "as" <+> text a
+
+  pretty (TySymDecl m ty args exp _) =
+    keyword "type" <+> prettyAcc m <> pretty ty <+> hsep (map ((squote <>) . pretty) args) <+> pretty exp
 
   pretty (Module am m bod) =
     vsep [ keyword "module" <+> prettyAcc am <> pretty m <+> equals <+> keyword "begin"

--- a/src/Syntax/Verify.hs
+++ b/src/Syntax/Verify.hs
@@ -60,12 +60,16 @@ verifyProgram = traverse_ verifyStmt where
     addBind = case am of
       Private -> Set.insert
       Public -> flip const
-  verifyStmt Class{} = pure ()
-  verifyStmt Instance{} = pure ()
+
   verifyStmt st@(ForeignVal _ v d _ (_, _)) =
     case parseExpr (SourcePos ("definition of " ++ displayS (pretty v)) 1 1) (d ^. lazy) of
       Left e -> tell (Seq.singleton (ParseErrorInForeign st e))
       Right _ -> pure ()
+
+  verifyStmt Class{} = pure ()
+  verifyStmt Instance{} = pure ()
+  verifyStmt TySymDecl{} = pure ()
+
 
   verifyStmt TypeDecl{} = pure ()
   verifyStmt (Module _ _ p) = verifyProgram p

--- a/src/Types/Infer.hs-boot
+++ b/src/Types/Infer.hs-boot
@@ -16,6 +16,7 @@ import Control.Monad.Infer
 
 import Syntax.Subst
 import Syntax.Var
+import Syntax.Types (TySyms)
 import Syntax
 
 import Types.Kinds
@@ -26,4 +27,4 @@ check :: forall m. MonadInfer Typed m => Expr Desugared -> Type Typed -> m (Expr
 
 infer :: MonadInfer Typed m => Expr Desugared -> m (Expr Typed, Type Typed)
 
-solveEx :: Type Typed -> Subst Typed -> Map.Map (Var Typed) (Wrapper Typed) -> Expr Typed -> Expr Typed
+solveEx :: TySyms -> Subst Typed -> Map.Map (Var Typed) (Wrapper Typed) -> Expr Typed -> Expr Typed

--- a/src/Types/Infer/Constructor.hs
+++ b/src/Types/Infer/Constructor.hs
@@ -26,7 +26,7 @@ inferCon :: MonadInfer Typed m
 
 inferCon vars ret con@(ArgCon ac nm t ann) = do
   checkWildcard con t
-  ty' <- resolveKind (BecauseOf con) t
+  ty' <- expandType =<< resolveKind (BecauseOf con) t
   res <- closeOver' vars (BecauseOf con) $ TyArr ty' ret
   pure ((nm, res), ArgCon ac nm ty' (ann, res))
 
@@ -49,7 +49,7 @@ inferCon vars ret c@(GadtCon ac nm cty ann) = do
 
   (cty, cons) <- runWriterT (generalise cty)
   let (sub, keep) = partitionEithers (map (uncurry simplify) cons)
-  overall <- closeOverGadt vars (BecauseOf c) keep (apply (mconcat sub) cty)
+  overall <- expandType =<< closeOverGadt vars (BecauseOf c) keep (apply (mconcat sub) cty)
   pure ((nm, overall), GadtCon ac nm overall (ann, overall))
 
 closeOverGadt :: MonadInfer Typed m => Set.Set (Var Typed) -> SomeReason -> [(Type Typed, Type Typed)] -> Type Typed -> m (Type Typed)

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -641,7 +641,7 @@ subsumes' r scope (TyApp lazy ty') ty | lazy == tyLazy, lazySubOk ty' ty = do
   pure (WrapFn (MkWrapCont wrap "automatic forcing"))
 
 subsumes' r scope ty' (TyApp lazy ty) | lazy == tyLazy, lazySubOk ty ty' = do
-  co <- subsumes' r scope ty ty'
+  wp <- subsumes' r scope ty ty'
   -- We have a value and want a thunk
   let wrap ex
         | an <- annotation ex =
@@ -649,7 +649,7 @@ subsumes' r scope ty' (TyApp lazy ty) | lazy == tyLazy, lazySubOk ty ty' = do
                 (an, lAZYTy' ty))
               -- So put it in a function to delay evaluation!
               (Fun (PatParam (PLiteral LiUnit (an, tyUnit)))
-                (ExprWrapper co ex (an, ty'))
+                (ExprWrapper wp ex (an, ty'))
                 (an, TyArr tyUnit ty))
               (an, TyApp lazy ty)
   pure (WrapFn (MkWrapCont wrap "automatic thunking"))

--- a/tests/lua/as_pattern.lua
+++ b/tests/lua/as_pattern.lua
@@ -1,7 +1,7 @@
 do
-  local function main(cf)
-    local b = cf.a
-    return b.a + b.b + cf.c
+  local function main(ch)
+    local b = ch.a
+    return b.a + b.b + ch.c
   end
   (nil)(main)
 end

--- a/tests/lua/default-method.lua
+++ b/tests/lua/default-method.lua
@@ -1,4 +1,4 @@
 do
   local use = print
-  use(function(ek) return "tail()" end)
+  use(function(fb) return "tail()" end)
 end

--- a/tests/lua/emit_ifs.lua
+++ b/tests/lua/emit_ifs.lua
@@ -4,14 +4,14 @@ do
   local function _bar_bar(a) return function(b) return a or b end end
   local function _not(a) return not a end
   (nil)({ ands = _amp_amp, ors = _bar_bar, ["not"] = _not })
-  (nil)(function(fy)
+  (nil)(function(gk)
     if true then
       return print("L")
     end
     print("R")
     return print("R")
   end)
-  (nil)(function(gj)
+  (nil)(function(gv)
     if not true then
       return print("R")
     end

--- a/tests/lua/lazy.lua
+++ b/tests/lua/lazy.lua
@@ -16,7 +16,7 @@ do
     end
   end
   (nil)({
-    _1 = __builtin_Lazy(function(y) return 2 end),
-    _2 = function(x) return __builtin_force(x) end
+    _2 = function(x) return __builtin_force(x) end,
+    _1 = __builtin_Lazy(function(z) return 2 end)
   })
 end

--- a/tests/lua/let_pattern.lua
+++ b/tests/lua/let_pattern.lua
@@ -1,4 +1,4 @@
 do
-  local eg = { _1 = function(x) return x end, _2 = function(x) return x end }
-  (nil)({ d = eg._1, e = eg._2, a = 3, b = 5, c = 6 })
+  local em = { _1 = function(x) return x end, _2 = function(x) return x end }
+  (nil)({ d = em._1, e = em._2, a = 3, b = 5, c = 6 })
 end

--- a/tests/lua/list.lua
+++ b/tests/lua/list.lua
@@ -6,12 +6,12 @@ do
   (nil)(Cons({ _1 = 2, _2 = Nil }))
   local function j(k)
     if k.__tag == "Cons" then
-      local nj = k[1]
-      local m, l = nj._1, nj._2
+      local ns = k[1]
+      local m, l = ns._1, ns._2
       local function n(o)
         if o.__tag == "Cons" then
-          local mu = o[1]
-          return Cons({ _2 = n(mu._2), _1 = { _1 = m, _2 = mu._1 } })
+          local nd = o[1]
+          return Cons({ _2 = n(nd._2), _1 = { _1 = m, _2 = nd._1 } })
         else
           return j(l)
         end
@@ -24,12 +24,12 @@ do
   (nil)(j(Cons({ _1 = 1, _2 = Cons({ _1 = 2, _2 = Cons({ _1 = 3, _2 = Nil }) }) })))
   local function r(s)
     if s.__tag == "Cons" then
-      local ov = s[1]
-      local u, t = ov._1, ov._2
+      local pe = s[1]
+      local u, t = pe._1, pe._2
       local b = u + 1
       local function v(w)
         if w.__tag == "Cons" then
-          return Cons({ _2 = v(w[1]._2), _1 = { _1 = u, _2 = b } })
+          return Cons({ _1 = { _1 = u, _2 = b }, _2 = v(w[1]._2) })
         else
           return r(t)
         end

--- a/tests/lua/match_heuristic.lua
+++ b/tests/lua/match_heuristic.lua
@@ -1,11 +1,11 @@
 do
   local function common_prefix(f)
-    local di = f._1
-    local dh = f._2
-    if di == 1 then
-      if dh == 2 then
+    local _do = f._1
+    local dn = f._2
+    if _do == 1 then
+      if dn == 2 then
         return "foo"
-      elseif dh == 3 then
+      elseif dn == 3 then
         return "bar"
       else
         return error("Pattern matching failure in match expression at match_heuristic.ml[2:21 ..2:28]")
@@ -15,12 +15,12 @@ do
     end
   end
   local function common_suffix(g)
-    local dl = g._1
-    local dk = g._2
-    if dl == 1 then
-      if dk == 2 then
+    local dr = g._1
+    local dq = g._2
+    if dr == 1 then
+      if dq == 2 then
         return "foo"
-      elseif dk == 3 then
+      elseif dq == 3 then
         return "bar"
       else
         return error("Pattern matching failure in match expression at match_heuristic.ml[6:21 ..6:28]")
@@ -30,26 +30,26 @@ do
     end
   end
   local function mixed_1(h)
-    local dn = h._2
-    local dq, dp = dn._1, dn._2
+    local dt = h._2
+    local dw, dv = dt._1, dt._2
     if h._1 then
-      if dq == 1 then
+      if dw == 1 then
         return 1
       else
-        if dp.__tag == "Cons" then
+        if dv.__tag == "Cons" then
           return 3
         else
           return error("Pattern matching failure in match expression at match_heuristic.ml[11:15 ..11:22]")
         end
       end
     else
-      if dp.__tag == "Nil" then
-        if dq == 2 then
+      if dv.__tag == "Nil" then
+        if dw == 2 then
           return 2
         else
           return error("Pattern matching failure in match expression at match_heuristic.ml[11:15 ..11:22]")
         end
-      elseif dp.__tag == "Cons" then
+      elseif dv.__tag == "Cons" then
         return 3
       end
     end

--- a/tests/lua/match_multi.lua
+++ b/tests/lua/match_multi.lua
@@ -1,4 +1,4 @@
 do
-  local bm = (nil)(nil)
-  (nil)(bm.a + bm.b)
+  local bp = (nil)(nil)
+  (nil)(bp.a + bp.b)
 end

--- a/tests/lua/monoid.lua
+++ b/tests/lua/monoid.lua
@@ -3,46 +3,46 @@ do
   local Nil = { __tag = "Nil" }
   local tostring = tostring
   local writeln = print
-  local function _dollardApplicativeaew(caw)
+  local function _dollardApplicativeais(chu)
     return {
-      pure = function(cai) return caw.zero end,
-      ["<*>"] = function(caz) return function(caw0) return caw["×"](caz)(caw0) end end,
-      ["Applicative$kl"] = function(cah) return function(cae) return cae end end
+      pure = function(chg) return chu.zero end,
+      ["<*>"] = function(cgx) return function(cgu) return chu["×"](cgx)(cgu) end end,
+      ["Applicative$ma"] = function(cgf) return function(cgc) return cgc end end
     }
   end
   local function _colon_colon(x) return function(y) return Cons({ _1 = x, _2 = y }) end end
-  local function _dollarshow(ass, cs)
+  local function _dollarshow(axo, cs)
     if cs.__tag == "Nil" then
       return "Nil"
     elseif cs.__tag == "Cons" then
-      local ccr = cs[1]
-      return ass(ccr._1) .. " :: " .. _dollarshow(ass, ccr._2)
+      local cjp = cs[1]
+      return axo(cjp._1) .. " :: " .. _dollarshow(axo, cjp._2)
     end
   end
-  local function _dollartraverse(bhn, cgr, k, cu)
+  local function _dollartraverse(bnq, cnp, k, cu)
     if cu.__tag == "Nil" then
-      return cgr.pure(Nil)
+      return cnp.pure(Nil)
     elseif cu.__tag == "Cons" then
-      local cgo = cu[1]
-      return cgr["<*>"](cgr["Applicative$kl"](_colon_colon)(k(cgo._1)))(_dollartraverse(nil, cgr, k, cgo._2))
+      local cnm = cu[1]
+      return cnp["<*>"](cnp["Applicative$ma"](_colon_colon)(k(cnm._1)))(_dollartraverse(nil, cnp, k, cnm._2))
     end
   end
-  local function _dollar_d7(blz, x, ys)
+  local function _dollar_d7(bsg, x, ys)
     if x.__tag == "Nil" then
       return ys
     elseif x.__tag == "Cons" then
-      local cho = x[1]
-      return Cons({ _2 = _dollar_d7(nil, cho._2, ys), _1 = cho._1 })
+      local com = x[1]
+      return Cons({ _1 = com._1, _2 = _dollar_d7(nil, com._2, ys) })
     end
   end
-  local cit = { _1 = 1, _2 = nil }
+  local cpr = { _1 = 1, _2 = nil }
   writeln(_dollarshow(function(x)
     return tostring(x)
-  end, _dollartraverse(nil, _dollardApplicativeaew({
+  end, _dollartraverse(nil, _dollardApplicativeais({
     zero = Nil,
     ["×"] = function(x) return function(ys) return _dollar_d7(nil, x, ys) end end
-  }), function(cbh) return Cons({ _1 = cbh._1, _2 = Nil }) end, Cons({
-    _1 = cit,
-    _2 = Cons({ _1 = cit, _2 = Cons({ _1 = cit, _2 = Nil }) })
+  }), function(cif) return Cons({ _1 = cif._1, _2 = Nil }) end, Cons({
+    _1 = cpr,
+    _2 = Cons({ _1 = cpr, _2 = Cons({ _1 = cpr, _2 = Nil }) })
   }))))
 end

--- a/tests/lua/nested_match.lua
+++ b/tests/lua/nested_match.lua
@@ -5,21 +5,21 @@ do
     if xs.__tag == "Nil" then
       return Cons({ _1 = 1, _2 = Nil })
     elseif xs.__tag == "Cons" then
-      local fs = xs[1]
+      local ge = xs[1]
       if ys.__tag == "Nil" then
         return Cons({ _1 = 2, _2 = Nil })
       elseif ys.__tag == "Cons" then
-        local ft = ys[1]
-        local fx, fw = ft._1, ft._2
-        local fv, fu = fs._1, fs._2
-        if fv == 0 then
-          if fx == 0 then
+        local gf = ys[1]
+        local gj, gi = gf._1, gf._2
+        local gh, gg = ge._1, ge._2
+        if gh == 0 then
+          if gj == 0 then
             return Cons({ _1 = 3, _2 = Nil })
           else
-            return Cons({ _1 = f(0)(fx), _2 = zip(f, fu, fw) })
+            return Cons({ _1 = f(0)(gj), _2 = zip(f, gg, gi) })
           end
         else
-          return Cons({ _1 = f(fv)(fx), _2 = zip(f, fu, fw) })
+          return Cons({ _1 = f(gh)(gj), _2 = zip(f, gg, gi) })
         end
       end
     end

--- a/tests/lua/nested_match_basic.lua
+++ b/tests/lua/nested_match_basic.lua
@@ -5,12 +5,12 @@ do
     if xs.__tag == "Nil" then
       return Cons({ _1 = 1, _2 = Nil })
     elseif xs.__tag == "Cons" then
-      local fl = xs[1]
+      local fx = xs[1]
       if ys.__tag == "Nil" then
         return Cons({ _1 = 2, _2 = Nil })
       elseif ys.__tag == "Cons" then
-        local fm = ys[1]
-        return Cons({ _1 = f(fl._1)(fm._1), _2 = zip(f, fl._2, fm._2) })
+        local fy = ys[1]
+        return Cons({ _1 = f(fx._1)(fy._1), _2 = zip(f, fx._2, fy._2) })
       end
     end
   end

--- a/tests/lua/newtype.lua
+++ b/tests/lua/newtype.lua
@@ -1,9 +1,9 @@
 do
   local function It(x) return { __tag = "It", x } end
   local function Mk(x) return { __tag = "Mk", x } end
-  local function Foo(fs) return fs end
+  local function Foo(gi) return gi end
   (nil)(Foo)
-  (nil)(function(ft) return ft end)
+  (nil)(function(gj) return gj end)
   (nil)(It)
   (nil)(Mk)
 end

--- a/tests/lua/op_apply.lua
+++ b/tests/lua/op_apply.lua
@@ -1,8 +1,8 @@
 do
   (nil)({
-    op = function(cc) return cc end,
+    op = function(ce) return ce end,
     app = 2,
     rsec = function(e) return e(2) end,
-    lsec = function(cd) return cd end
+    lsec = function(cf) return cf end
   })
 end

--- a/tests/lua/opt_constant_fold.lua
+++ b/tests/lua/opt_constant_fold.lua
@@ -1,6 +1,6 @@
 do
-  (nil)(function(je)
-    local i, s = je.i, je.s
+  (nil)(function(jf)
+    local i, s = jf.i, jf.s
     return {
       int_add_c = 5,
       int_sub_c = -1,
@@ -30,7 +30,7 @@ do
       bol_ne_c = true,
       uni_eq = true,
       uni_ne = false,
-      app = je.fn(je.x),
+      app = jf.fn(jf.x),
       int_eq_u = true,
       int_ne_u = false,
       str_eq_u = true,

--- a/tests/lua/optimise_sink.lua
+++ b/tests/lua/optimise_sink.lua
@@ -2,7 +2,7 @@ do
   local Nil = { __tag = "Nil" }
   local function main(x)
     if x.__tag == "Nil" then
-      return function(cm) return { _1 = 1, _2 = x } end
+      return function(cq) return { _1 = 1, _2 = x } end
     elseif x.__tag == "Cons" then
       return function(x0) return { _1 = x0, _2 = Nil } end
     end

--- a/tests/lua/pattern_guard.lua
+++ b/tests/lua/pattern_guard.lua
@@ -5,8 +5,8 @@ do
     if k.__tag == "Nil" then
       return Nil
     elseif k.__tag == "Cons" then
-      local ed = k[1]
-      local x, xs = ed._1, ed._2
+      local en = k[1]
+      local x, xs = en._1, en._2
       if f(x) then
         return Cons({ _1 = x, _2 = filter(f, xs) })
       end

--- a/tests/lua/pattern_multiple_consume.lua
+++ b/tests/lua/pattern_multiple_consume.lua
@@ -1,6 +1,6 @@
 do
-  local function main(av)
-    local x = av.x
+  local function main(ax)
+    local x = ax.x
     return x + main({ x = x })
   end
   main({ x = 1 })

--- a/tests/lua/precedence.lua
+++ b/tests/lua/precedence.lua
@@ -1,6 +1,6 @@
 do
-  local function main(ff)
-    local a, b, c = ff.a, ff.b, ff.c
+  local function main(fi)
+    local a, b, c = fi.a, fi.b, fi.c
     (nil)((a + b) * c)
     (nil)(a * (b + c))
     (nil)(a ^ b * c)

--- a/tests/lua/record_extend.lua
+++ b/tests/lua/record_extend.lua
@@ -1,9 +1,9 @@
 do
-  local ay = {}
+  local ba = {}
   local __o = nil
   for k, v in pairs(__o) do
-    ay[k] = v
+    ba[k] = v
   end
-  ay.x = 1
-  (nil)(ay)
+  ba.x = 1
+  (nil)(ba)
 end

--- a/tests/lua/recursive_defaults.lua
+++ b/tests/lua/recursive_defaults.lua
@@ -1,10 +1,10 @@
 do
   local use = print
-  local function _dollardShowci(fj)
+  local function _dollardShowcx(gb)
     return {
-      show = function(fb) return "()" end,
-      ["show'"] = function(dz) return _dollardShowci(nil).show(dz) end
+      show = function(ft) return "()" end,
+      ["show'"] = function(eq) return _dollardShowcx(nil).show(eq) end
     }
   end
-  use(_dollardShowci(nil).show)
+  use(_dollardShowcx(nil).show)
 end

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -1,10 +1,10 @@
 do
-  local function _plus0(bz) return function(ca) return bz + ca end end
+  local function _plus0(ce) return function(cf) return ce + cf end end
   local main = {
     _1 = _plus0,
     _2 = {
-      _2 = { _1 = function(d) return d / 2 end, _2 = function(e) return e.foo end },
-      _1 = function(cd) return 2 * cd end
+      _1 = function(ci) return 2 * ci end,
+      _2 = { _1 = function(d) return d / 2 end, _2 = function(e) return e.foo end }
     }
   }
   (nil)(main)

--- a/tests/lua/stream-zip.lua
+++ b/tests/lua/stream-zip.lua
@@ -7,41 +7,41 @@ do
   local function Stream(x) return { __tag = "Stream", x } end
   local print = print
   local to_string = tostring
-  local function zip(bcq)
-    local bcs = bcq[1]
-    local f, start = bcs._1, bcs._2
-    return function(bcl)
-      local bcn = bcl[1]
-      local g = bcn._1
+  local function zip(bga)
+    local bgc = bga[1]
+    local f, start = bgc._1, bgc._2
+    return function(bfv)
+      local bfx = bfv[1]
+      local g = bfx._1
       return Stream({
-        _2 = { _1 = start, _2 = { _1 = bcn._2, _2 = None } },
-        _1 = function(bbz)
-          local bcb = bbz._2
-          local sb = bcb._1
-          local x = bcb._2
-          local sa = bbz._1
+        _2 = { _1 = start, _2 = { _2 = None, _1 = bfx._2 } },
+        _1 = function(bfj)
+          local bfl = bfj._2
+          local sb = bfl._1
+          local x = bfl._2
+          local sa = bfj._1
           if x.__tag == "Some" then
+            local ben = g(sb)
             local x0 = x[1]
-            local bbd = g(sb)
-            if bbd.__tag == "Skip" then
-              return Skip({ _1 = sa, _2 = { _2 = Some(x0), _1 = bbd[1] } })
-            elseif bbd.__tag == "Yield" then
-              local bbu = bbd[1]
+            if ben.__tag == "Skip" then
+              return Skip({ _1 = sa, _2 = { _1 = ben[1], _2 = Some(x0) } })
+            elseif ben.__tag == "Yield" then
+              local bfe = ben[1]
               return Yield({
-                _1 = { _1 = x0, _2 = bbu._1 },
-                _2 = { _1 = sa, _2 = { _1 = bbu._2, _2 = None } }
+                _1 = { _1 = x0, _2 = bfe._1 },
+                _2 = { _1 = sa, _2 = { _2 = None, _1 = bfe._2 } }
               })
-            elseif bbd.__tag == "Done" then
+            elseif ben.__tag == "Done" then
               return Done
             end
           elseif x.__tag == "None" then
-            local bal = f(sa)
-            if bal.__tag == "Skip" then
-              return Skip({ _2 = { _1 = sb, _2 = None }, _1 = bal[1] })
-            elseif bal.__tag == "Yield" then
-              local bba = bal[1]
-              return Skip({ _2 = { _1 = sb, _2 = Some(bba._1) }, _1 = bba._2 })
-            elseif bal.__tag == "Done" then
+            local bdv = f(sa)
+            if bdv.__tag == "Skip" then
+              return Skip({ _1 = bdv[1], _2 = { _1 = sb, _2 = None } })
+            elseif bdv.__tag == "Yield" then
+              local bek = bdv[1]
+              return Skip({ _2 = { _1 = sb, _2 = Some(bek._1) }, _1 = bek._2 })
+            elseif bdv.__tag == "Done" then
               return Done
             end
           end
@@ -49,7 +49,7 @@ do
       })
     end
   end
-  local axm = zip(Stream({
+  local baw = zip(Stream({
     _1 = function(n)
       if n > 100 then
         return Done
@@ -66,18 +66,18 @@ do
     end,
     _2 = 100
   }))[1]
-  local go = axm._1
+  local go = baw._1
   local function go0(ac, st)
-    local awu = go(st)
-    if awu.__tag == "Skip" then
-      return go0(ac, awu[1])
-    elseif awu.__tag == "Yield" then
-      local axe = awu[1]
-      local x = axe._1
-      return go0(x._1 + x._2 + ac, axe._2)
-    elseif awu.__tag == "Done" then
+    local bae = go(st)
+    if bae.__tag == "Skip" then
+      return go0(ac, bae[1])
+    elseif bae.__tag == "Yield" then
+      local bao = bae[1]
+      local x = bao._1
+      return go0(x._1 + x._2 + ac, bao._2)
+    elseif bae.__tag == "Done" then
       return ac
     end
   end
-  print(to_string(go0(0, axm._2)))
+  print(to_string(go0(0, baw._2)))
 end

--- a/tests/lua/stream.lua
+++ b/tests/lua/stream.lua
@@ -2,7 +2,6 @@ do
   local io_write = io.write
   local print = print
   local to_string = tostring
-  io_write("[")
   local function go(st)
     if st > 5 then
       return print("]")
@@ -10,6 +9,7 @@ do
     io_write("'" .. to_string(st) .. "', ")
     return go(st + 1)
   end
+  io_write("[")
   local main = go(1)
   (nil)(main)
 end

--- a/tests/lua/values_occ.lua
+++ b/tests/lua/values_occ.lua
@@ -3,15 +3,15 @@ do
   local print = print
   local to_string = tostring
   local function sum_squares(xs)
-    local iy = xs[1]
-    local go = iy._1
+    local jt = xs[1]
+    local go = jt._1
     return Stream({
       _1 = function(st)
-        local jq = go(st)
-        local x = jq._1
-        return { _1 = x * x, _2 = jq._2 }
+        local kl = go(st)
+        local x = kl._1
+        return { _1 = x * x, _2 = kl._2 }
       end,
-      _2 = iy._2
+      _2 = jt._2
     })
   end
   print(to_string(sum_squares))

--- a/tests/types/class/class02.out
+++ b/tests/types/class/class02.out
@@ -3,6 +3,6 @@ class02.ml[3:3 ..3:27]: error
 3 │   val foo : 'a () -> string
   │   ^^^^^^^^^^^^^^^^^^^^^^^^^
   Couldn't match actual type type
-    with the type expected by the context, 'i -> 'j
+    with the type expected by the context, 'k -> 'l
 
   • Did you apply a type constructor to too many arguments?

--- a/tests/types/class/class07.out
+++ b/tests/types/class/class07.out
@@ -4,7 +4,7 @@ class07.ml[9:9 ..9:32]: error
   │         ^^^^^^^^^^^^^^^^^^^^^^^^
   Ambiguous type for value foo
 
-    show 'a * read 'a * show 'ci => 'ci -> string
+    show 'a * read 'a * show 'cy => 'cy -> string
 
   • Note: The variable a appears in a constraint,
       but not in the consequent of the type

--- a/tests/types/class/mtpc-scope.out
+++ b/tests/types/class/mtpc-scope.out
@@ -1,10 +1,10 @@
 functor : (type -> type) -> constraint
 map : Spec{'f : type -> type}. functor 'f => Spec{'a : type}. Spec{'b : type}. ('a -> 'b) -> 'f 'a -> 'f 'b
 foldable : (type -> type) -> constraint
-iapplicative : Infer{'in : type}. ('in -> 'in -> type -> type) -> constraint
-pure : Spec{'f : 'in -> 'in -> type -> type}. iapplicative 'f => Infer{'in : type}. Spec{'a : type}. Spec{'i : 'in}. 'a -> 'f 'i 'i 'a
-<*> : Spec{'f : 'in -> 'in -> type -> type}. iapplicative 'f => Infer{'in : type}. Spec{'a : type}. Spec{'b : type}. Spec{'i : 'in}. Spec{'j : 'in}. Spec{'k : 'in}. 'f 'i 'j ('a -> 'b) -> 'f 'j 'k 'a -> 'f 'i 'k 'b
-imonad : Infer{'uh : type}. ('uh -> 'uh -> type -> type) -> constraint
->>= : Spec{'m : 'uh -> 'uh -> type -> type}. imonad 'm => Infer{'uh : type}. Spec{'a : type}. Spec{'b : type}. Spec{'i : 'uh}. Spec{'j : 'uh}. Spec{'k : 'uh}. ('a -> 'm 'j 'k 'b) -> 'm 'i 'j 'a -> 'm 'i 'k 'b
+iapplicative : Infer{'jt : type}. ('jt -> 'jt -> type -> type) -> constraint
+pure : Spec{'f : 'jt -> 'jt -> type -> type}. iapplicative 'f => Infer{'jt : type}. Spec{'a : type}. Spec{'i : 'jt}. 'a -> 'f 'i 'i 'a
+<*> : Spec{'f : 'jt -> 'jt -> type -> type}. iapplicative 'f => Infer{'jt : type}. Spec{'a : type}. Spec{'b : type}. Spec{'i : 'jt}. Spec{'j : 'jt}. Spec{'k : 'jt}. 'f 'i 'j ('a -> 'b) -> 'f 'j 'k 'a -> 'f 'i 'k 'b
+imonad : Infer{'xi : type}. ('xi -> 'xi -> type -> type) -> constraint
+>>= : Spec{'m : 'xi -> 'xi -> type -> type}. imonad 'm => Infer{'xi : type}. Spec{'a : type}. Spec{'b : type}. Spec{'i : 'xi}. Spec{'j : 'xi}. Spec{'k : 'xi}. ('a -> 'm 'j 'k 'b) -> 'm 'i 'j 'a -> 'm 'i 'k 'b
 iio : Infer{'a : type}. Infer{'b : type}. 'b -> 'a -> type -> type
 IIO : Infer{'a : type}. Infer{'b : type}. Spec{'before : 'b}. Spec{'after : 'a}. Spec{'a : type}. (unit -> 'a) -> iio 'before 'after 'a

--- a/tests/types/class/polyrec-class.out
+++ b/tests/types/class/polyrec-class.out
@@ -2,7 +2,7 @@ nat : type
 Z : nat
 S : nat -> nat
 vect : nat -> type -> type
-Nil : Infer{'bz : type}. Spec{'n : 'bz}. Spec{'a : type}. ('n ~ Z) ⊃ vect 'n 'a
-Cons : Infer{'dh : type}. Spec{'n : 'dh}. Spec{'a : type}. Spec{'k : nat}. ('n ~ S 'k) ⊃ ('a * vect 'k 'a) -> vect 'n 'a
+Nil : Infer{'cd : type}. Spec{'n : 'cd}. Spec{'a : type}. ('n ~ Z) ⊃ vect 'n 'a
+Cons : Infer{'dm : type}. Spec{'n : 'dm}. Spec{'a : type}. Spec{'k : nat}. ('n ~ S 'k) ⊃ ('a * vect 'k 'a) -> vect 'n 'a
 functor : (type -> type) -> constraint
 map : Spec{'f : type -> type}. functor 'f => Spec{'a : type}. Spec{'b : type}. ('a -> 'b) -> 'f 'a -> 'f 'b

--- a/tests/types/class/recursive01.out
+++ b/tests/types/class/recursive01.out
@@ -1,4 +1,4 @@
 show : type -> constraint
 show : Spec{'a : type}. show 'a => 'a -> string
-foo : Infer{'a : type}. Infer{'b : 'cv}. show 'a => 'a -> 'b
-bar : Infer{'a : type}. Infer{'b : 'de}. show 'a => 'a -> 'b
+foo : Infer{'a : type}. Infer{'b : type}. show 'a => 'a -> 'b
+bar : Infer{'a : type}. Infer{'b : type}. show 'a => 'a -> 'b

--- a/tests/types/class/recursive02.out
+++ b/tests/types/class/recursive02.out
@@ -2,5 +2,5 @@ show : type -> constraint
 show : Spec{'a : type}. show 'a => 'a -> string
 dostuff : type -> constraint
 stuff : Spec{'a : type}. dostuff 'a => 'a -> unit
-foo : Infer{'a : type}. Infer{'b : 'ft}. dostuff 'a => 'a -> 'b
-bar : Infer{'a : type}. Infer{'b : 'gc}. dostuff 'a => 'a -> 'b
+foo : Infer{'a : type}. Infer{'b : type}. dostuff 'a => 'a -> 'b
+bar : Infer{'a : type}. Infer{'b : type}. dostuff 'a => 'a -> 'b

--- a/tests/types/gadt/gadt03-pass.out
+++ b/tests/types/gadt/gadt03-pass.out
@@ -1,5 +1,5 @@
 to_string : Spec{'a : type}. 'a -> string
 term : type -> type
-B : Infer{'as : type}. Spec{'a : 'as}. ('a ~ bool) ⊃ bool -> term 'a
-I : Infer{'bm : type}. Spec{'a : 'bm}. ('a ~ int) ⊃ int -> term 'a
+B : Infer{'ax : type}. Spec{'a : 'ax}. ('a ~ bool) ⊃ bool -> term 'a
+I : Infer{'bt : type}. Spec{'a : 'bt}. ('a ~ int) ⊃ int -> term 'a
 show : Spec{'a : type}. term 'a -> string

--- a/tests/types/gadt/gadt05-pass.out
+++ b/tests/types/gadt/gadt05-pass.out
@@ -1,4 +1,4 @@
 t : type -> type -> type
-T : Infer{'au : type}. Spec{'t : 'au}. Spec{'a : type}. ('t ~ unit) ⊃ 'a -> t 't 'a
+T : Infer{'ay : type}. Spec{'t : 'ay}. Spec{'a : type}. ('t ~ unit) ⊃ 'a -> t 't 'a
 foo : Spec{'a : type}. Spec{'t : type}. ('a -> 'a) -> t 't 'a -> t 't 'a
 bar : Spec{'t : type}. t 't int -> t 't int

--- a/tests/types/gadt/gadt06-pass.out
+++ b/tests/types/gadt/gadt06-pass.out
@@ -1,7 +1,7 @@
 exp : type
 ast : type -> type -> type
-Var : Infer{'bo : type}. Infer{'bp : type}. Spec{'a : 'bo}. Spec{'b : 'bp}. Infer{'tag : type}. ('a ~ exp, 'b ~ 'tag) ⊃ string -> ast 'a 'b
-Tag : Infer{'cz : type}. Spec{'b : 'cz}. Spec{'a : type}. Spec{'tag : type}. ('b ~ 'tag) ⊃ ('tag * ast 'a 'tag) -> ast 'a 'b
+Var : Infer{'bt : type}. Infer{'bu : type}. Spec{'a : 'bt}. Spec{'b : 'bu}. Infer{'tag : type}. ('a ~ exp, 'b ~ 'tag) ⊃ string -> ast 'a 'b
+Tag : Infer{'dg : type}. Spec{'b : 'dg}. Spec{'a : type}. Spec{'tag : type}. ('b ~ 'tag) ⊃ ('tag * ast 'a 'tag) -> ast 'a 'b
 foo : type
 Foo : int -> foo
 convert : Spec{'a : type}. Spec{'tag : type}. ast 'a 'tag -> ast 'a foo

--- a/tests/types/gadt/gadt08-pass.out
+++ b/tests/types/gadt/gadt08-pass.out
@@ -2,10 +2,10 @@ list : type -> type
 Nil : Spec{'a : type}. list 'a
 Cons : Spec{'a : type}. ('a * list 'a) -> list 'a
 elem : Infer{'a : type}. 'a -> list 'a -> type
-Here : Infer{'ez : type}. Infer{'a : type}. Spec{'xs : 'ez}. Spec{'x : 'a}. Infer{'xs : list 'a}. ('xs ~ Cons ('x * 'xs)) ⊃ elem 'x 'xs
-There : Infer{'gq : type}. Infer{'a : type}. Spec{'xs : 'gq}. Spec{'x : 'a}. Spec{'xs : list 'a}. Infer{'y : 'a}. ('xs ~ Cons ('y * 'xs)) ⊃ elem 'x 'xs -> elem 'x 'xs
+Here : Infer{'fg : type}. Infer{'a : type}. Spec{'xs : 'fg}. Spec{'x : 'a}. Infer{'xs : list 'a}. ('xs ~ Cons ('x * 'xs)) ⊃ elem 'x 'xs
+There : Infer{'gy : type}. Infer{'a : type}. Spec{'xs : 'gy}. Spec{'x : 'a}. Spec{'xs : list 'a}. Infer{'y : 'a}. ('xs ~ Cons ('y * 'xs)) ⊃ elem 'x 'xs -> elem 'x 'xs
 product : list type -> type
-Unit : Infer{'jd : type}. Spec{'a : 'jd}. ('a ~ Nil) ⊃ product 'a
-Pair : Infer{'kg : type}. Spec{'a : 'kg}. Spec{'a : type}. Spec{'b : list type}. ('a ~ Cons ('a * 'b)) ⊃ ('a * product 'b) -> product 'a
+Unit : Infer{'jo : type}. Spec{'a : 'jo}. ('a ~ Nil) ⊃ product 'a
+Pair : Infer{'ks : type}. Spec{'a : 'ks}. Spec{'a : type}. Spec{'b : list type}. ('a ~ Cons ('a * 'b)) ⊃ ('a * product 'b) -> product 'a
 :: : Infer{'a : type}. Infer{'b : list type}. 'a -> product 'b -> product (Cons ('a * 'b))
 foo : product (Cons (int * Cons (unit * Cons (string * Cons (bool * Cons (float * Nil))))))

--- a/tests/types/gadt/gadt09-pass.out
+++ b/tests/types/gadt/gadt09-pass.out
@@ -1,8 +1,8 @@
 print : string -> unit
 repr : type -> type
-Unit : Infer{'cc : type}. Spec{'a : 'cc}. ('a ~ unit) ⊃ repr 'a
-Pair : Infer{'dd : type}. Spec{'a : 'dd}. Spec{'a : type}. Spec{'b : type}. ('a ~ 'a * 'b) ⊃ (repr 'a * repr 'b) -> repr 'a
-Int : Infer{'ec : type}. Spec{'a : 'ec}. ('a ~ int) ⊃ repr 'a
+Unit : Infer{'cf : type}. Spec{'a : 'cf}. ('a ~ unit) ⊃ repr 'a
+Pair : Infer{'dh : type}. Spec{'a : 'dh}. Spec{'a : type}. Spec{'b : type}. ('a ~ 'a * 'b) ⊃ (repr 'a * repr 'b) -> repr 'a
+Int : Infer{'eh : type}. Spec{'a : 'eh}. ('a ~ int) ⊃ repr 'a
 option : type -> type
 Some : Spec{'a : type}. 'a -> option 'a
 None : Spec{'a : type}. option 'a

--- a/tests/types/gadt/pass_existential.out
+++ b/tests/types/gadt/pass_existential.out
@@ -4,8 +4,8 @@ natural : type
 Z : natural
 S : natural -> natural
 nat : natural -> type
-Zero : Infer{'cb : type}. Spec{'n : 'cb}. ('n ~ Z) ⊃ nat 'n
-Succ : Infer{'cy : type}. Spec{'n : 'cy}. Spec{'k : natural}. ('n ~ S 'k) ⊃ nat 'k -> nat 'n
+Zero : Infer{'cg : type}. Spec{'n : 'cg}. ('n ~ Z) ⊃ nat 'n
+Succ : Infer{'de : type}. Spec{'n : 'de}. Spec{'k : natural}. ('n ~ S 'k) ⊃ nat 'k -> nat 'n
 some_nat : type
 SomeNat : Spec{'n : natural}. nat 'n -> some_nat
 with_natural : Infer{'a : type}. int -> (Spec{'n : natural}. nat 'n -> 'a) -> 'a

--- a/tests/types/gadt/pass_guard.out
+++ b/tests/types/gadt/pass_guard.out
@@ -1,3 +1,3 @@
 foo : type -> type
-Foo : Infer{'z : type}. Spec{'a : 'z}. ('a ~ bool) ⊃ foo 'a
+Foo : Infer{'aa : type}. Spec{'a : 'aa}. ('a ~ bool) ⊃ foo 'a
 bar : Spec{'a : type}. ('a * foo 'a) -> int

--- a/tests/types/gadt/pass_product.out
+++ b/tests/types/gadt/pass_product.out
@@ -1,9 +1,9 @@
 list : type -> type
-Nil : Infer{'bi : type}. Spec{'tys : 'bi}. ('tys ~ unit) ⊃ list 'tys
-Cons : Infer{'ch : type}. Spec{'tys : 'ch}. Spec{'a : type}. Spec{'b : type}. ('tys ~ 'a * 'b) ⊃ ('a * list 'b) -> list 'tys
+Nil : Infer{'bk : type}. Spec{'tys : 'bk}. ('tys ~ unit) ⊃ list 'tys
+Cons : Infer{'ck : type}. Spec{'tys : 'ck}. Spec{'a : type}. Spec{'b : type}. ('tys ~ 'a * 'b) ⊃ ('a * list 'b) -> list 'tys
 elem : Infer{'a : type}. 'a -> 'a -> type
-Here : Infer{'fa : type}. Infer{'a : type}. Spec{'xs : 'fa}. Spec{'x : 'a}. Infer{'xs : 'a}. ('xs ~ 'x * 'xs) ⊃ elem 'x 'xs
-There : Infer{'gl : type}. Infer{'a : type}. Spec{'xs : 'gl}. Spec{'x : 'a}. Spec{'xs : 'a}. Infer{'y : 'a}. ('xs ~ 'y * 'xs) ⊃ elem 'x 'xs -> elem 'x 'xs
+Here : Infer{'fh : type}. Infer{'a : type}. Spec{'xs : 'fh}. Spec{'x : 'a}. Infer{'xs : 'a}. ('xs ~ 'x * 'xs) ⊃ elem 'x 'xs
+There : Infer{'gt : type}. Infer{'a : type}. Spec{'xs : 'gt}. Spec{'x : 'a}. Spec{'xs : 'a}. Infer{'y : 'a}. ('xs ~ 'y * 'xs) ⊃ elem 'x 'xs -> elem 'x 'xs
 index : Spec{'a : type}. Spec{'ts : type}. elem 'a 'ts -> list 'ts -> 'a
 :: : Infer{'a : type}. Infer{'b : type}. 'a -> list 'b -> list ('a * 'b)
 foo : string

--- a/tests/types/gadt/pass_term.out
+++ b/tests/types/gadt/pass_term.out
@@ -1,11 +1,11 @@
 list : type -> type
-Nil : Infer{'bl : type}. Spec{'tys : 'bl}. ('tys ~ unit) ⊃ list 'tys
-Cons : Infer{'ck : type}. Spec{'tys : 'ck}. Spec{'a : type}. Spec{'b : type}. ('tys ~ 'a * 'b) ⊃ ('a * list 'b) -> list 'tys
+Nil : Infer{'bn : type}. Spec{'tys : 'bn}. ('tys ~ unit) ⊃ list 'tys
+Cons : Infer{'cn : type}. Spec{'tys : 'cn}. Spec{'a : type}. Spec{'b : type}. ('tys ~ 'a * 'b) ⊃ ('a * list 'b) -> list 'tys
 elem : Infer{'a : type}. 'a -> 'a -> type
-Here : Infer{'fd : type}. Infer{'a : type}. Spec{'xs : 'fd}. Spec{'x : 'a}. Infer{'xs : 'a}. ('xs ~ 'x * 'xs) ⊃ elem 'x 'xs
-There : Infer{'go : type}. Infer{'a : type}. Spec{'xs : 'go}. Spec{'x : 'a}. Spec{'xs : 'a}. Infer{'y : 'a}. ('xs ~ 'y * 'xs) ⊃ elem 'x 'xs -> elem 'x 'xs
+Here : Infer{'fk : type}. Infer{'a : type}. Spec{'xs : 'fk}. Spec{'x : 'a}. Infer{'xs : 'a}. ('xs ~ 'x * 'xs) ⊃ elem 'x 'xs
+There : Infer{'gw : type}. Infer{'a : type}. Spec{'xs : 'gw}. Spec{'x : 'a}. Spec{'xs : 'a}. Infer{'y : 'a}. ('xs ~ 'y * 'xs) ⊃ elem 'x 'xs -> elem 'x 'xs
 term : type -> type -> type
 Var : Spec{'ctx : type}. Spec{'ty : type}. elem 'ty 'ctx -> term 'ctx 'ty
-Lam : Infer{'mf : type}. Spec{'ty : 'mf}. Spec{'a : type}. Spec{'b : type}. Spec{'ctx : type}. ('ty ~ 'a -> 'b) ⊃ term ('a * 'ctx) 'b -> term 'ctx 'ty
-App : Infer{'od : type}. Spec{'ty : 'od}. Spec{'a : type}. Spec{'b : type}. Spec{'ctx : type}. ('ty ~ 'b) ⊃ (term 'ctx ('a -> 'b) * term 'ctx 'a) -> term 'ctx 'ty
+Lam : Infer{'na : type}. Spec{'ty : 'na}. Spec{'a : type}. Spec{'b : type}. Spec{'ctx : type}. ('ty ~ 'a -> 'b) ⊃ term ('a * 'ctx) 'b -> term 'ctx 'ty
+App : Infer{'pc : type}. Spec{'ty : 'pc}. Spec{'a : type}. Spec{'b : type}. Spec{'ctx : type}. ('ty ~ 'b) ⊃ (term 'ctx ('a -> 'b) * term 'ctx 'a) -> term 'ctx 'ty
 const : Infer{'a : type}. Infer{'ctx : type}. Infer{'b : type}. term 'ctx ('a -> 'b -> 'a)

--- a/tests/types/gadt/pass_vector.out
+++ b/tests/types/gadt/pass_vector.out
@@ -2,8 +2,8 @@ natural : type
 Z : natural
 S : natural -> natural
 vect : natural -> type -> type
-Nil : Infer{'bu : type}. Spec{'n : 'bu}. Spec{'a : type}. ('n ~ Z) ⊃ vect 'n 'a
-Cons : Infer{'dc : type}. Spec{'n : 'dc}. Spec{'a : type}. Spec{'k : natural}. ('n ~ S 'k) ⊃ ('a * vect 'k 'a) -> vect 'n 'a
+Nil : Infer{'by : type}. Spec{'n : 'by}. Spec{'a : type}. ('n ~ Z) ⊃ vect 'n 'a
+Cons : Infer{'dh : type}. Spec{'n : 'dh}. Spec{'a : type}. Spec{'k : natural}. ('n ~ S 'k) ⊃ ('a * vect 'k 'a) -> vect 'n 'a
 head : Infer{'a : type}. Infer{'k : natural}. vect (S 'k) 'a -> 'a
 tail : Infer{'a : type}. Infer{'k : natural}. vect (S 'k) 'a -> vect 'k 'a
 main : int

--- a/tests/types/rankn/impredicative01-fail.out
+++ b/tests/types/rankn/impredicative01-fail.out
@@ -2,5 +2,5 @@ impredicative01-fail.ml[6:38 ..6:52]: error
   │ 
 6 │ let foo : id (forall 'a. 'a -> 'a) = Id (fun x -> x)
   │                                      ^^^^^^^^^^^^^^^
-  Couldn't match actual type id ('ae -> 'ae)
+  Couldn't match actual type id ('ah -> 'ah)
     with the type expected by the context, id (forall 'a. 'a -> 'a)

--- a/tests/types/rankn/record03-fail.out
+++ b/tests/types/rankn/record03-fail.out
@@ -3,6 +3,6 @@ record03-fail.ml[5:20 ..5:24]: error
 5 │ let main (Foo r) = r.baz 1
   │                    ^^^^^
   No overlap between exact record { bar : forall 'a. 'a -> 'a }
-           and polymorphic record { 'az | baz : 'ay }
+           and polymorphic record { 'be | baz : 'bd }
   • Note: no fields match
   • The following fields are missing: baz

--- a/tests/types/synonym/syn01.ml
+++ b/tests/types/synonym/syn01.ml
@@ -1,0 +1,3 @@
+type two_of 'a <- 'a * 'a
+
+let x : two_of int = (1, 1)

--- a/tests/types/synonym/syn01.out
+++ b/tests/types/synonym/syn01.out
@@ -1,0 +1,2 @@
+two_of : Infer{'a : type}. 'a -> 'a
+x : int * int

--- a/tests/types/synonym/syn02.ml
+++ b/tests/types/synonym/syn02.ml
@@ -1,0 +1,7 @@
+type two_of 'a <- 'a * 'a
+type two_int <- two_of int
+
+let foo : two_int = (1, 1)
+let bar : two_of int = foo
+let bar : int * int = foo
+

--- a/tests/types/synonym/syn02.out
+++ b/tests/types/synonym/syn02.out
@@ -1,0 +1,5 @@
+two_of : Infer{'a : type}. 'a -> 'a
+two_int : type
+foo : int * int
+bar : int * int
+bar : int * int

--- a/tests/types/synonym/syn03.ml
+++ b/tests/types/synonym/syn03.ml
@@ -1,0 +1,6 @@
+type two_of 'a <- 'a * 'a
+
+let foo : list (two_of int) = [(1, 1)]
+let bar (x : list (int * int)) = ()
+
+let _ = bar foo

--- a/tests/types/synonym/syn03.out
+++ b/tests/types/synonym/syn03.out
@@ -1,0 +1,3 @@
+two_of : Infer{'a : type}. 'a -> 'a
+foo : list (int * int)
+bar : list (int * int) -> unit

--- a/tests/types/synonym/syn04.ml
+++ b/tests/types/synonym/syn04.ml
@@ -1,0 +1,6 @@
+type 'f ~> 'g <- forall 'x. 'f 'x -> 'g 'x
+
+type id 'x = Id of 'x
+
+let foo : id ~> list =
+  fun (Id x) -> [x]

--- a/tests/types/synonym/syn04.out
+++ b/tests/types/synonym/syn04.out
@@ -1,0 +1,4 @@
+~> : Infer{'a : type}. ('a -> type) -> ('a -> type) -> type
+id : type -> type
+Id : Spec{'x : type}. 'x -> id 'x
+foo : Spec{'a : type}. Spec{'x : 'a}. id 'x -> list 'x

--- a/tests/types/synonym/syn05.ml
+++ b/tests/types/synonym/syn05.ml
@@ -1,0 +1,4 @@
+type foo 'a <- 'a * 'a
+
+class x 'a begin end
+instance x foo begin end

--- a/tests/types/synonym/syn05.out
+++ b/tests/types/synonym/syn05.out
@@ -1,0 +1,6 @@
+syn05.ml[4:1 ..4:24]: error
+  │ 
+4 │ instance x foo begin end
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+  Type synonym foo appears with no arguments,
+  but in its definition it has 1

--- a/tests/types/synonym/syn06.ml
+++ b/tests/types/synonym/syn06.ml
@@ -1,0 +1,4 @@
+type foo <- ( * ) int 
+
+class x 'a begin end
+instance x foo begin end

--- a/tests/types/synonym/syn06.out
+++ b/tests/types/synonym/syn06.out
@@ -1,0 +1,2 @@
+foo : Infer{'a : type}. type -> 'a
+x : Infer{'p : type}. 'p -> constraint

--- a/tests/types/synonym/syn07.ml
+++ b/tests/types/synonym/syn07.ml
@@ -1,0 +1,4 @@
+type foo 'a <- ( * ) int 'a
+
+class x 'a begin end
+instance x foo begin end

--- a/tests/types/synonym/syn07.out
+++ b/tests/types/synonym/syn07.out
@@ -1,0 +1,6 @@
+syn07.ml[4:1 ..4:24]: error
+  │ 
+4 │ instance x foo begin end
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^
+  Type synonym foo appears with no arguments,
+  but in its definition it has 1

--- a/tests/types/synonym/syn08.ml
+++ b/tests/types/synonym/syn08.ml
@@ -1,0 +1,4 @@
+type foo 'a 'b <- 'a * 'b
+
+class x 'a begin end
+instance x (foo int) begin end

--- a/tests/types/synonym/syn08.out
+++ b/tests/types/synonym/syn08.out
@@ -1,0 +1,6 @@
+syn08.ml[4:1 ..4:30]: error
+  │ 
+4 │ instance x (foo int) begin end
+  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  Type synonym foo appears with one argument,
+  but in its definition it has 2

--- a/tests/types/vta/vta-class01.out
+++ b/tests/types/vta/vta-class01.out
@@ -1,2 +1,2 @@
-sized : Infer{'h : type}. 'h -> constraint
-size : Infer{'v : type}. Spec{'a : 'v}. sized 'a => Infer{'v : type}. Spec{'proxy : 'v -> type}. 'proxy 'a -> int
+sized : Infer{'i : type}. 'i -> constraint
+size : Infer{'y : type}. Spec{'a : 'y}. sized 'a => Infer{'y : type}. Spec{'proxy : 'y -> type}. 'proxy 'a -> int

--- a/tests/types/vta/vta-fail03.out
+++ b/tests/types/vta/vta-fail03.out
@@ -2,5 +2,5 @@ vta-fail03.ml[1:13 ..1:18]: error
   │ 
 1 │ let foo x = x @int
   │             ^^^^^^
-  Can not apply expression of type 'k
+  Can not apply expression of type 'l
     to visible type argument int


### PR DESCRIPTION
These are declared like

```ocaml
  type foo [args] <- expansion
```

and They Behave Like You Expect[citation needed]