### PR TITLE
Differentiate between user-provided and temporary variables

### DIFF
--- a/compiler/Repl.hs
+++ b/compiler/Repl.hs
@@ -282,8 +282,8 @@ execString name line = do
               vs' <- for vs $ \(v, _) -> do
                 let Just (_, vs) = VarMap.lookup v (emit' ^. B.topVars)
                 repr <- traverse (valueRepr . evalExpr . B.unsimple) vs
-                let CoVar id nam _ = v
-                    var = S.TgName nam id
+                let CoVar id _ _ = v
+                    var = S.TgName (covarDisplayName v) id
                 case inferScope state' ^. T.names . at var of
                   Just ty -> pure (Just (pretty v <+> colon <+> nest 2 (displayType ty <+> equals </> hsep (map pretty repr))))
                   Nothing -> pure Nothing

--- a/src/Backend/Escape.hs
+++ b/src/Backend/Escape.hs
@@ -63,7 +63,7 @@ pushVar v s = escapeVar (toVar v) where
   escapeVar v@(CoVar _ name _) =
     case Map.lookup v (toEsc s) of
       Just n -> (n, s)
-      Nothing -> pushFirst Nothing (escape s name)
+      Nothing -> pushFirst Nothing (escape s (fromMaybe "tmp" name))
 
   pushFirst :: Maybe Int -> T.Text -> (T.Text, EscapeScope)
   pushFirst prefix esc =

--- a/src/Backend/Lua/Builtin.hs
+++ b/src/Backend/Lua/Builtin.hs
@@ -8,8 +8,6 @@ module Backend.Lua.Builtin
   , builtinBuilders
   ) where
 
-import Control.Lens
-
 import qualified Data.VarMap as VarMap
 import qualified Data.Sequence as Seq
 import qualified Data.Text as T
@@ -184,7 +182,7 @@ builtins =
 
   where
     genOp (var, op) =
-      let name = escaper (var ^. covarName)
+      let name = escaper (covarDisplayName var)
           name_ = LuaName name
           inner = LuaBinOp (LuaRef left) op (LuaRef right)
       in ( var, name, []

--- a/src/Backend/Lua/Emit.hs
+++ b/src/Backend/Lua/Emit.hs
@@ -168,7 +168,7 @@ toGraph = Graph DirectedGraph
 
 instance IsVar a => Pretty (VarMap.Map (EmittedNode a)) where
   pretty = drawGraph disp . toGraph where
-    disp (CoVar id name _) = text name <> "_" <> int' id
+    disp v@(CoVar id _ _) = text (covarDisplayName v) <> "_" <> int' id
     int' x | x < 0 = "_" <> int (-x)
            | otherwise = int x
 

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -17,7 +17,7 @@ module Control.Monad.Infer
   , Constraint(..)
   , Env
   , MonadInfer, Name
-  , lookupTy, lookupTy', genNameFrom, genNameWith, runInfer, freeInEnv
+  , lookupTy, lookupTy', runInfer, freeInEnv
   , difference, freshTV, refreshTV
   , instantiate
   , SomeReason(..), Reasonable, addBlame
@@ -218,16 +218,6 @@ runInfer :: MonadNamey m
          -> m (These [TypeError] (a, Seq.Seq (Constraint p)))
 runInfer ct ac = over here toList <$>
   runChronicleT (runWriterT (runReaderT ac ct))
-
-genNameFrom :: MonadNamey m => Text -> m (Var Desugared)
-genNameFrom t = do
-  ~(TgName _ n) <- genName
-  pure (TgName t n)
-
-genNameWith :: MonadNamey m => Text -> m (Var Desugared)
-genNameWith t = do
-  ~(TgName e n) <- genName
-  pure (TgName (t <> e) n)
 
 firstName :: Var Desugared
 firstName = TgName "a" 0

--- a/src/Control/Monad/Namey.hs
+++ b/src/Control/Monad/Namey.hs
@@ -14,6 +14,7 @@ module Control.Monad.Namey
   ( NameyT, runNameyT, evalNameyT
   , Namey, runNamey, evalNamey
   , MonadNamey(..)
+  , genNameFrom, genNameWith
   , genAlnum
   ) where
 
@@ -150,3 +151,15 @@ genAlnum n = go (fromIntegral n) T.empty (floor (logBase 26 (fromIntegral n :: D
               0 -> 1
               x -> x
      in go (n `mod'` (26 ^ p)) (T.snoc out (chr (96 + m))) (p - 1)
+
+-- | Generate a fresh var with a specific name.
+genNameFrom :: MonadNamey m => T.Text -> m (Var Desugared)
+genNameFrom t = do
+  ~(TgName _ n) <- genName
+  pure (TgName t n)
+
+-- | Generate a fresh var prepended with another name.
+genNameWith :: MonadNamey m => T.Text -> m (Var Desugared)
+genNameWith t = do
+  ~(TgName e n) <- genName
+  pure (TgName (t <> e) n)

--- a/src/Core/Builtin.hs
+++ b/src/Core/Builtin.hs
@@ -283,4 +283,4 @@ fakeKINT =
 
 makeBuiltins :: [ (Text, VarInfo) ] -> [CoVar]
 makeBuiltins xs = zipWith go xs [-1, -2 ..] where
-  go (name, t) id = CoVar id name t
+  go (name, t) id = CoVar id (Just name) t

--- a/src/Core/Lint.hs
+++ b/src/Core/Lint.hs
@@ -465,7 +465,7 @@ checkNoUnboxed ValuesTy{} = pushError IllegalUnbox
 checkNoUnboxed _ = pure ()
 
 unknownVar :: IsVar a => a
-unknownVar = fromVar (CoVar (-100) "?" ValueVar)
+unknownVar = fromVar (CoVar (-100) (Just "?") ValueVar)
 
 unknownTyvar :: IsVar a => Type a
 unknownTyvar = VarTy unknownVar

--- a/src/Core/Lower.hs
+++ b/src/Core/Lower.hs
@@ -188,7 +188,7 @@ lowerAt (ExprWrapper wrap e an) ty =
     S.TypeLam (Skolem (TgName _ id) (TgName n _) _ _) k ->
       let ty' (ForallTy (Relevant v) _ t) = substituteInType (VarMap.singleton v (VarTy var)) t
           ty' x = x
-          var = CoVar id n TypeVar
+          var = CoVar id (Just n) TypeVar
        in Lam (TypeArgument var (lowerType k)) <$> lowerAtTerm e (ty' ty)
     S.TypeLam _ _ -> error "impossible lowerAt TypeLam"
     ws S.:> wy -> lowerAt (ExprWrapper ws (ExprWrapper wy e an) an) ty
@@ -414,8 +414,8 @@ lowerLet bs =
       patternExtract pos p test ty outerTy (var, (_, innerTy)) = do
         let var' = mkVal var
             innerTy' = lowerType innerTy
-        pvar@(CoVar vn vt _) <- freshFrom var'
-        let p' = stripPtrn var (TgName vt vn) p
+        pvar@(CoVar vn _ _) <- freshFrom var'
+        let p' = stripPtrn var (TgName (covarDisplayName pvar) vn) p
 
         -- Generate `let x = match test with | ... x' ... -> x`
         One  . (var', outerTy, ) <$> patternWrap pos p' test ty outerTy (Atom (Ref pvar innerTy')) innerTy'

--- a/src/Core/Lower/Basic.hs
+++ b/src/Core/Lower/Basic.hs
@@ -48,7 +48,7 @@ mkCon = mkVar DataConVar
 
 -- | Make a core variable from a "Syntax" variable and a given kind.
 mkVar :: VarInfo -> Var Resolved -> CoVar
-mkVar k (TgName t i) = CoVar i t k
+mkVar k (TgName n i) = CoVar i (Just n) k
 mkVar _ n@TgInternal{} = error ("Cannot convert " ++ show n ++ " to CoVar")
 
 -- | Lower a type from "Syntax" to one in "Core.Core".
@@ -77,7 +77,7 @@ lowerType (S.TyCon v)
   | v == Bi.tyConstraintName = StarTy
   | otherwise = ConTy (mkType v)
 lowerType (S.TyPromotedCon v) = ConTy (mkCon v) -- TODO this is in the wrong scope
-lowerType (S.TySkol (Skolem (TgName _ v) (TgName n _) _ _)) = VarTy (CoVar v n TypeVar)
+lowerType (S.TySkol (Skolem (TgName _ v) (TgName n _) _ _)) = VarTy (CoVar v (Just n) TypeVar)
 lowerType (S.TySkol _) = error "impossible lowerType TySkol"
 lowerType (S.TyOperator l o r)
   | o == Bi.tyTupleName = lowerType (S.TyTuple l r)

--- a/src/Core/Optimise.hs
+++ b/src/Core/Optimise.hs
@@ -233,8 +233,8 @@ freshFrom' x = fromVar <$> freshFrom (toVar x)
 -- | Create a fresh 'CoVar'
 fresh :: MonadNamey m => VarInfo -> m CoVar
 fresh k = do
-  ~(TgName nam x) <- genName
-  pure (CoVar x nam k)
+  ~(TgName _ x) <- genName
+  pure (CoVar x Nothing k)
 
 -- | Create a fresh variable
 fresh' :: (MonadNamey m, IsVar a) => VarInfo -> m a

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -10,14 +10,16 @@ import qualified Data.Text as T
 import Data.Hashable
 
 import Control.Lens
-import GHC.Generics
+import Control.Monad.Namey
+
 import Text.Pretty.Semantic
+import GHC.Generics
 import Data.Data
 
 -- | The core variable type
 data CoVar =
   CoVar { _covarId :: {-# UNPACK #-} !Int -- ^ The unique identifier for this variable.
-        , _covarName :: T.Text -- ^ The name of this variable.
+        , _covarName :: Maybe T.Text -- ^ The name of this variable
         , _covarInfo :: VarInfo -- ^ Additional information about this variable.
         }
   deriving (Show, Generic, Data)
@@ -44,8 +46,12 @@ data VarInfo
 makeLenses ''CoVar
 makePrisms ''VarInfo
 
+covarDisplayName :: CoVar -> T.Text
+covarDisplayName (CoVar i Nothing _) = genAlnum i
+covarDisplayName (CoVar _ (Just n) _) = n
+
 instance Pretty CoVar where
-  pretty (CoVar i v k) = text v <> scomment (string "#" <> pretty k <> string (show i))
+  pretty v@(CoVar i _ k) = text (covarDisplayName v) <> scomment (string "#" <> pretty k <> shown i)
 
 instance Pretty VarInfo where
   pretty ValueVar = text "v"

--- a/src/Core/Var.hs
+++ b/src/Core/Var.hs
@@ -19,7 +19,7 @@ import Data.Data
 -- | The core variable type
 data CoVar =
   CoVar { _covarId :: {-# UNPACK #-} !Int -- ^ The unique identifier for this variable.
-        , _covarName :: Maybe T.Text -- ^ The name of this variable
+        , _covarName :: Maybe T.Text -- ^ The name of this variable.
         , _covarInfo :: VarInfo -- ^ Additional information about this variable.
         }
   deriving (Show, Generic, Data)

--- a/src/Syntax/Builtin.hs
+++ b/src/Syntax/Builtin.hs
@@ -335,7 +335,7 @@ builtinEnv = go builtins where
 
 -- | Construct a syntax variable from a core one
 ofCore :: CoVar -> Var Resolved
-ofCore (CoVar i n _) = TgName n i
+ofCore v@(CoVar i _ _) = TgName (covarDisplayName v) i
 
 -- Declare some syntactic sugar to make building types easier
 (~>) :: Type Typed -> Type Typed -> Type Typed

--- a/src/Syntax/Desugar.hs
+++ b/src/Syntax/Desugar.hs
@@ -17,6 +17,7 @@ module Syntax.Desugar (desugarProgram) where
 
 import Control.Monad.Namey
 
+import Data.Text (Text)
 import Data.Bifunctor
 import Data.Foldable
 import Data.Spanned
@@ -58,7 +59,11 @@ expr (Fun p b a) = Fun (param p) <$> expr b <*> pure a
 expr (Begin es a) = Begin <$> traverse expr es <*> pure a
 expr (Match e bs a) = Match <$> expr e <*> traverse arm bs <*> pure a
 expr (Function bs a) = do
-  (cap, rhs) <- fresh a
+  let name = case bs of
+               [] -> "bot"
+               [Arm b _ _] | Just n <- getPatternName b -> n
+               _ -> "x"
+  (cap, rhs) <- fresh name a
   Fun (EvParam cap) <$>
     (Match rhs <$> traverse arm bs <*> pure a)
     <*> pure a
@@ -71,7 +76,7 @@ expr (RecordExt e rs a) = RecordExt <$> expr e <*> traverse field rs <*> pure a
 expr (Access e k a) = Access <$> expr e <*> pure k <*> pure a
 
 expr (LeftSection op vl an) = do
-  (cap, rhs) <- fresh an
+  (cap, rhs) <- fresh "r" an
   op' <- expr op
   vl' <- expr vl
   let go lhs = Fun (PatParam cap) (BinOp rhs op' lhs an) an
@@ -79,14 +84,14 @@ expr (LeftSection op vl an) = do
     VarRef{} -> pure $ go vl'
     Literal{} -> pure $ go vl'
     _ -> do
-      ~(Capture lv _, ref) <- fresh an
+      ~(Capture lv _, ref) <- fresh "x" an
       pure $ Let [Binding lv vl' False an] (go ref) an
 
 expr (RightSection vl op an) = expr (App op vl an)
 expr (BothSection o _) = expr o
 
 expr (AccessSection k a) = do
-  (cap, ref) <- fresh a
+  (cap, ref) <- fresh "tbl" a
   pure (Fun (PatParam cap) (Access ref k a) a)
 
 expr (Parens e _) = expr e
@@ -119,12 +124,12 @@ buildTuple :: forall m. MonadNamey m => Ann Desugared
            -> ([Pattern Desugared], [(Var Desugared, Expr Desugared)], [Expr Desugared])
            -> m ([Pattern Desugared], [(Var Desugared, Expr Desugared)], [Expr Desugared])
 buildTuple a Nothing (as, vs, tuple) = do
-  (p, v) <- fresh a
+  (p, v) <- fresh "a" a
   pure (p:as, vs, v:tuple)
 buildTuple _ (Just e@VarRef{}) (as, vs, tuple) = pure (as, vs, e:tuple)
 buildTuple _ (Just e@Literal{}) (as, vs, tuple) = pure (as, vs, e:tuple)
 buildTuple a (Just e) (as, vs, tuple) = do
-  ~(Capture v _, ref) <- fresh a
+  ~(Capture v _, ref) <- fresh "x" a
   pure (as, (v, e):vs, ref:tuple)
 
 binding :: forall m. MonadNamey m => Binding Resolved -> m (Binding Desugared)
@@ -203,9 +208,9 @@ transListComp :: forall m. MonadNamey m
               -> Expr Desugared -> m (Expr Desugared)
 transListComp (ex, CompGen v l1 an:qs, an') l2 = do
   h <- genName
-  (cus, us) <- fresh an
-  (cus', us') <- fresh an
-  (cx, x) <- fresh an
+  (cus, us) <- fresh "xss" an
+  (cus', us') <- fresh "xs" an
+  (cx, x) <- fresh "x" an
   l1 <- expr l1
   success <- transListComp (ex, qs, an) (App (VarRef h an) us' an)
   pure $
@@ -272,7 +277,13 @@ refutable (PRecord rs _) = any (refutable . snd) rs
 refutable (PTuple ps _) = any refutable ps
 refutable PGadtCon{} = undefined
 
-fresh :: MonadNamey m => Ann Desugared -> m (Pattern Desugared, Expr Desugared)
-fresh an = do
-  var <- genName
+fresh :: MonadNamey m => Text -> Ann Desugared -> m (Pattern Desugared, Expr Desugared)
+fresh n an = do
+  var <- genNameFrom n
   pure (Capture var an, VarRef var an)
+
+getPatternName :: Pattern Resolved -> Maybe Text
+getPatternName (Capture (TgName n _) _) = Just n
+getPatternName (PAs _ (TgName n _) _) = Just n
+getPatternName (PType p _ _) = getPatternName p
+getPatternName _ = Nothing

--- a/tests/lua/as_pattern.lua
+++ b/tests/lua/as_pattern.lua
@@ -1,7 +1,7 @@
 do
-  local function main(g)
-    local b = g.a
-    return b.a + b.b + g.c
+  local function main(x)
+    local b = x.a
+    return b.a + b.b + x.c
   end
   (nil)(main)
 end

--- a/tests/lua/emit_ifs.lua
+++ b/tests/lua/emit_ifs.lua
@@ -4,14 +4,14 @@ do
   local function _bar_bar(a) return function(b) return a or b end end
   local function _not(a) return not a end
   (nil)({ ands = _amp_amp, ors = _bar_bar, ["not"] = _not })
-  (nil)(function(hk)
+  (nil)(function(tmp)
     if true then
       return print("L")
     end
     print("R")
     return print("R")
   end)
-  (nil)(function(hz)
+  (nil)(function(tmp)
     if not true then
       return print("R")
     end
@@ -24,8 +24,8 @@ do
   if not true then
     print("Hello")
   end
-  (nil)(function(n)
-    if n == 0 then
+  (nil)(function(x)
+    if x == 0 then
       return nil
     end
     print("Not 0")

--- a/tests/lua/lazy.lua
+++ b/tests/lua/lazy.lua
@@ -17,6 +17,6 @@ do
   local function __builtin_Lazy(x) return { x, false, __tag = "lazy" } end
   (nil)({
     _2 = function(x) return __builtin_force(x) end,
-    _1 = __builtin_Lazy(function(ab) return 2 end)
+    _1 = __builtin_Lazy(function(tmp) return 2 end)
   })
 end

--- a/tests/lua/let_pattern.lua
+++ b/tests/lua/let_pattern.lua
@@ -1,4 +1,4 @@
 do
-  local et = { _1 = function(x) return x end, _2 = function(x) return x end }
-  (nil)({ d = et._1, e = et._2, a = 3, b = 5, c = 6 })
+  local tmp = { _1 = function(x) return x end, _2 = function(x) return x end }
+  (nil)({ d = tmp._1, e = tmp._2, a = 3, b = 5, c = 6 })
 end

--- a/tests/lua/list.lua
+++ b/tests/lua/list.lua
@@ -4,36 +4,36 @@ do
   (nil)(Cons({ _1 = 1, _2 = Cons({ _1 = 2, _2 = Cons({ _1 = 3, _2 = Nil }) }) }))
   (nil)(1)
   (nil)(Cons({ _1 = 2, _2 = Nil }))
-  local function j(k)
-    if k.__tag ~= "Cons" then
+  local function j(xss)
+    if xss.__tag ~= "Cons" then
       return Nil
     end
-    local no = k[1]
-    local m, l = no._1, no._2
-    local function n(o)
-      if o.__tag ~= "Cons" then
-        return j(l)
+    local tmp = xss[1]
+    local x, xs = tmp._1, tmp._2
+    local function n(xss0)
+      if xss0.__tag ~= "Cons" then
+        return j(xs)
       end
-      local mv = o[1]
-      return Cons({ _2 = n(mv._2), _1 = { _1 = m, _2 = mv._1 } })
+      local tmp0 = xss0[1]
+      return Cons({ _2 = n(tmp0._2), _1 = { _1 = x, _2 = tmp0._1 } })
     end
     return n(Cons({ _1 = 4, _2 = Cons({ _1 = 5, _2 = Cons({ _1 = 6, _2 = Nil }) }) }))
   end
   (nil)(j(Cons({ _1 = 1, _2 = Cons({ _1 = 2, _2 = Cons({ _1 = 3, _2 = Nil }) }) })))
-  local function r(s)
-    if s.__tag ~= "Cons" then
+  local function r(xss)
+    if xss.__tag ~= "Cons" then
       return Nil
     end
-    local pl = s[1]
-    local u, t = pl._1, pl._2
-    local b = u + 1
-    local function v(w)
-      if w.__tag == "Cons" then
-        return Cons({ _1 = { _1 = u, _2 = b }, _2 = v(w[1]._2) })
+    local tmp = xss[1]
+    local x, xs = tmp._1, tmp._2
+    local b = x + 1
+    local function v(xss0)
+      if xss0.__tag == "Cons" then
+        return Cons({ _1 = { _1 = x, _2 = b }, _2 = v(xss0[1]._2) })
       end
-      return r(t)
+      return r(xs)
     end
-    return v(Cons({ _1 = b, _2 = Cons({ _1 = u, _2 = Nil }) }))
+    return v(Cons({ _1 = b, _2 = Cons({ _1 = x, _2 = Nil }) }))
   end
   (nil)(r(Cons({ _1 = 1, _2 = Cons({ _1 = 2, _2 = Cons({ _1 = 3, _2 = Nil }) }) })))
 end

--- a/tests/lua/match_heuristic.lua
+++ b/tests/lua/match_heuristic.lua
@@ -1,48 +1,48 @@
 do
-  local function common_prefix(f)
-    local dv = f._1
-    local du = f._2
-    if dv ~= 1 then
+  local function common_prefix(x)
+    local tmp = x._1
+    local tmp0 = x._2
+    if tmp ~= 1 then
       return error("Pattern matching failure in match expression at match_heuristic.ml[2:21 ..2:28]")
     end
-    if du == 2 then
+    if tmp0 == 2 then
       return "foo"
-    elseif du == 3 then
+    elseif tmp0 == 3 then
       return "bar"
     else
       return error("Pattern matching failure in match expression at match_heuristic.ml[2:21 ..2:28]")
     end
   end
-  local function common_suffix(g)
-    local dy = g._1
-    local dx = g._2
-    if dy ~= 1 then
+  local function common_suffix(x)
+    local tmp = x._1
+    local tmp0 = x._2
+    if tmp ~= 1 then
       return error("Pattern matching failure in match expression at match_heuristic.ml[6:21 ..6:28]")
     end
-    if dx == 2 then
+    if tmp0 == 2 then
       return "foo"
-    elseif dx == 3 then
+    elseif tmp0 == 3 then
       return "bar"
     else
       return error("Pattern matching failure in match expression at match_heuristic.ml[6:21 ..6:28]")
     end
   end
-  local function mixed_1(h)
-    local ea = h._2
-    local ed, ec = ea._1, ea._2
-    if h._1 then
-      if ed == 1 then
+  local function mixed_1(x)
+    local tmp = x._2
+    local tmp0, tmp1 = tmp._1, tmp._2
+    if x._1 then
+      if tmp0 == 1 then
         return 1
       end
-      if ec.__tag == "Cons" then
+      if tmp1.__tag == "Cons" then
         return 3
       end
       return error("Pattern matching failure in match expression at match_heuristic.ml[11:15 ..11:22]")
     else
-      if ec.__tag ~= "Nil" then
+      if tmp1.__tag ~= "Nil" then
         return 3
       end
-      if ed == 2 then
+      if tmp0 == 2 then
         return 2
       end
       return error("Pattern matching failure in match expression at match_heuristic.ml[11:15 ..11:22]")

--- a/tests/lua/match_multi.lua
+++ b/tests/lua/match_multi.lua
@@ -1,7 +1,7 @@
 do
   local function main(f)
-    local bi = f(nil)
-    return bi.a + bi.b
+    local tmp = f(nil)
+    return tmp.a + tmp.b
   end
   (nil)(main)
 end

--- a/tests/lua/monoid.lua
+++ b/tests/lua/monoid.lua
@@ -3,43 +3,43 @@ do
   local Nil = { __tag = "Nil" }
   local tostring = tostring
   local writeln = print
-  local function _dollardApplicativeajd(cks)
+  local function _dollardApplicativeajd(tmp)
     return {
-      ["<*>"] = function(cjs) return function(cjp) return cks["×"](cjs)(cjp) end end,
-      pure = function(ckd) return cks.zero end,
-      ["Applicative$ma"] = function(ciw) return function(cit) return cit end end
+      ["<*>"] = function(tmp0) return function(tmp1) return tmp["×"](tmp0)(tmp1) end end,
+      pure = function(tmp0) return tmp.zero end,
+      ["Applicative$ma"] = function(tmp0) return function(tmp1) return tmp1 end end
     }
   end
   local function _colon_colon(x) return function(y) return Cons({ _1 = x, _2 = y }) end end
-  local function _dollarshow(aym, cs)
-    if cs.__tag == "Nil" then
+  local function _dollarshow(aym, x)
+    if x.__tag == "Nil" then
       return "Nil"
     end
-    local cmv = cs[1]
-    return aym(cmv._1) .. " :: " .. _dollarshow(aym, cmv._2)
+    local tmp = x[1]
+    return aym(tmp._1) .. " :: " .. _dollarshow(aym, tmp._2)
   end
-  local function _dollartraverse(bpb, csi, k, cu)
-    if cu.__tag == "Nil" then
-      return csi.pure(Nil)
+  local function _dollartraverse(bpb, tmp, k, x)
+    if x.__tag == "Nil" then
+      return tmp.pure(Nil)
     end
-    local csf = cu[1]
-    return csi["<*>"](csi["Applicative$ma"](_colon_colon)(k(csf._1)))(_dollartraverse(nil, csi, k, csf._2))
+    local tmp0 = x[1]
+    return tmp["<*>"](tmp["Applicative$ma"](_colon_colon)(k(tmp0._1)))(_dollartraverse(nil, tmp, k, tmp0._2))
   end
   local function _dollar_d7(bua, x, ys)
     if x.__tag == "Nil" then
       return ys
     end
-    local ctn = x[1]
-    return Cons({ _1 = ctn._1, _2 = _dollar_d7(nil, ctn._2, ys) })
+    local tmp = x[1]
+    return Cons({ _1 = tmp._1, _2 = _dollar_d7(nil, tmp._2, ys) })
   end
-  local cux = { _1 = 1, _2 = nil }
+  local tmp = { _1 = 1, _2 = nil }
   writeln(_dollarshow(function(x)
     return tostring(x)
   end, _dollartraverse(nil, _dollardApplicativeajd({
     zero = Nil,
     ["×"] = function(x) return function(ys) return _dollar_d7(nil, x, ys) end end
-  }), function(cle) return Cons({ _1 = cle._1, _2 = Nil }) end, Cons({
-    _1 = cux,
-    _2 = Cons({ _1 = cux, _2 = Cons({ _1 = cux, _2 = Nil }) })
+  }), function(tmp0) return Cons({ _1 = tmp0._1, _2 = Nil }) end, Cons({
+    _1 = tmp,
+    _2 = Cons({ _1 = tmp, _2 = Cons({ _1 = tmp, _2 = Nil }) })
   }))))
 end

--- a/tests/lua/nested_match.lua
+++ b/tests/lua/nested_match.lua
@@ -5,20 +5,20 @@ do
     if xs.__tag == "Nil" then
       return Cons({ _1 = 1, _2 = Nil })
     end
-    local gj = xs[1]
+    local tmp = xs[1]
     if ys.__tag == "Nil" then
       return Cons({ _1 = 2, _2 = Nil })
     end
-    local gk = ys[1]
-    local go, gn = gk._1, gk._2
-    local gm, gl = gj._1, gj._2
-    if go ~= 0 then
-      return Cons({ _1 = f(gm)(go), _2 = zip(f, gl, gn) })
+    local tmp2 = ys[1]
+    local tmp3, tmp4 = tmp2._1, tmp2._2
+    local tmp0, tmp1 = tmp._1, tmp._2
+    if tmp3 ~= 0 then
+      return Cons({ _1 = f(tmp0)(tmp3), _2 = zip(f, tmp1, tmp4) })
     end
-    if gm == 0 then
+    if tmp0 == 0 then
       return Cons({ _1 = 3, _2 = Nil })
     end
-    return Cons({ _1 = f(gm)(0), _2 = zip(f, gl, gn) })
+    return Cons({ _1 = f(tmp0)(0), _2 = zip(f, tmp1, tmp4) })
   end
   local function zip0(f) return function(xs) return function(ys) return zip(f, xs, ys) end end end
   (nil)(zip0)

--- a/tests/lua/nested_match_basic.lua
+++ b/tests/lua/nested_match_basic.lua
@@ -5,12 +5,12 @@ do
     if xs.__tag == "Nil" then
       return Cons({ _1 = 1, _2 = Nil })
     end
-    local fy = xs[1]
+    local tmp = xs[1]
     if ys.__tag == "Nil" then
       return Cons({ _1 = 2, _2 = Nil })
     end
-    local fz = ys[1]
-    return Cons({ _1 = f(fy._1)(fz._1), _2 = zip(f, fy._2, fz._2) })
+    local tmp0 = ys[1]
+    return Cons({ _1 = f(tmp._1)(tmp0._1), _2 = zip(f, tmp._2, tmp0._2) })
   end
   local function zip0(f) return function(xs) return function(ys) return zip(f, xs, ys) end end end
   (nil)(zip0)

--- a/tests/lua/newtype.lua
+++ b/tests/lua/newtype.lua
@@ -1,9 +1,9 @@
 do
   local function It(a) return { __tag = "It", a } end
   local function Mk(a) return { __tag = "Mk", a } end
-  local function Foo(gp) return gp end
+  local function Foo(tmp) return tmp end
   (nil)(Foo)
-  (nil)(function(gq) return gq end)
+  (nil)(function(tmp) return tmp end)
   (nil)(It)
   (nil)(Mk)
 end

--- a/tests/lua/op_apply.lua
+++ b/tests/lua/op_apply.lua
@@ -1,8 +1,8 @@
 do
   (nil)({
-    op = function(cj) return cj end,
+    op = function(tmp) return tmp end,
     app = 2,
-    rsec = function(e) return e(2) end,
-    lsec = function(ck) return ck end
+    rsec = function(r) return r(2) end,
+    lsec = function(tmp) return tmp end
   })
 end

--- a/tests/lua/opt_constant_fold.lua
+++ b/tests/lua/opt_constant_fold.lua
@@ -1,6 +1,6 @@
 do
-  (nil)(function(js)
-    local i, s = js.i, js.s
+  (nil)(function(tmp)
+    local i, s = tmp.i, tmp.s
     return {
       int_add_c = 5,
       int_sub_c = -1,
@@ -30,7 +30,7 @@ do
       bol_ne_c = true,
       uni_eq = true,
       uni_ne = false,
-      app = js.fn(js.x),
+      app = tmp.fn(tmp.x),
       int_eq_u = true,
       int_ne_u = false,
       str_eq_u = true,

--- a/tests/lua/opt_single_match.lua
+++ b/tests/lua/opt_single_match.lua
@@ -1,5 +1,5 @@
 do
-  local function f(i) return i end
-  local function g(j) return j end
+  local function f(x) return x end
+  local function g(x) return x end
   (nil)({ f = f, g = g })
 end

--- a/tests/lua/optimise_sink.lua
+++ b/tests/lua/optimise_sink.lua
@@ -2,7 +2,7 @@ do
   local Nil = { __tag = "Nil" }
   local function main(x)
     if x.__tag == "Nil" then
-      return function(cl) return { _1 = 1, _2 = x } end
+      return function(tmp) return { _1 = 1, _2 = x } end
     end
     return function(x0) return { _1 = x0, _2 = Nil } end
   end

--- a/tests/lua/pattern_guard.lua
+++ b/tests/lua/pattern_guard.lua
@@ -1,17 +1,17 @@
 do
   local function Cons(x) return { x, __tag = "Cons" } end
   local Nil = { __tag = "Nil" }
-  local function filter(f, k)
-    if k.__tag == "Nil" then
+  local function filter(f, x)
+    if x.__tag == "Nil" then
       return Nil
     end
-    local eq = k[1]
-    local x, xs = eq._1, eq._2
-    if f(x) then
-      return Cons({ _1 = x, _2 = filter(f, xs) })
+    local tmp = x[1]
+    local x0, xs = tmp._1, tmp._2
+    if f(x0) then
+      return Cons({ _1 = x0, _2 = filter(f, xs) })
     end
     return filter(f, xs)
   end
-  local function filter0(f) return function(k) return filter(f, k) end end
+  local function filter0(f) return function(x) return filter(f, x) end end
   (nil)(filter0)
 end

--- a/tests/lua/pattern_multiple_consume.lua
+++ b/tests/lua/pattern_multiple_consume.lua
@@ -1,6 +1,6 @@
 do
-  local function main(ay)
-    local x = ay.x
+  local function main(tmp)
+    local x = tmp.x
     return x + main({ x = x })
   end
   main({ x = 1 })

--- a/tests/lua/precedence.lua
+++ b/tests/lua/precedence.lua
@@ -1,6 +1,6 @@
 do
-  local function main(fo)
-    local a, b, c = fo.a, fo.b, fo.c
+  local function main(tmp)
+    local a, b, c = tmp.a, tmp.b, tmp.c
     (nil)((a + b) * c)
     (nil)(a * (b + c))
     (nil)(a ^ b * c)

--- a/tests/lua/recursive_defaults.lua
+++ b/tests/lua/recursive_defaults.lua
@@ -1,8 +1,8 @@
 do
   local use = print
-  local function _dollardShowcz(gf)
+  local function _dollardShowcz(tmp)
     return {
-      show = function(fx) return "()" end,
+      show = function(tmp0) return "()" end,
       ["show'"] = function(et) return _dollardShowcz(nil).show(et) end
     }
   end

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -1,10 +1,10 @@
 do
-  local function _plus0(cb) return function(cc) return cb + cc end end
+  local function _plus0(tmp) return function(tmp0) return tmp + tmp0 end end
   local main = {
     _1 = _plus0,
     _2 = {
-      _1 = function(cf) return 2 * cf end,
-      _2 = { _1 = function(d) return d / 2 end, _2 = function(e) return e.foo end }
+      _1 = function(tmp) return 2 * tmp end,
+      _2 = { _1 = function(r) return r / 2 end, _2 = function(tbl) return tbl.foo end }
     }
   }
   (nil)(main)

--- a/tests/lua/stream-zip.lua
+++ b/tests/lua/stream-zip.lua
@@ -7,41 +7,41 @@ do
   local function Stream(a) return { __tag = "Stream", a } end
   local print = print
   local to_string = tostring
-  local function zip(bgv)
-    local bgx = bgv[1]
-    local f, start = bgx._1, bgx._2
-    return function(bgq)
-      local bgs = bgq[1]
-      local g = bgs._1
+  local function zip(tmp)
+    local tmp0 = tmp[1]
+    local f, start = tmp0._1, tmp0._2
+    return function(tmp1)
+      local tmp2 = tmp1[1]
+      local g = tmp2._1
       return Stream({
-        _2 = { _1 = start, _2 = { _1 = bgs._2, _2 = None } },
-        _1 = function(bgc)
-          local sa = bgc._1
-          local bge = bgc._2
-          local sb = bge._1
-          local x = bge._2
+        _2 = { _1 = start, _2 = { _1 = tmp2._2, _2 = None } },
+        _1 = function(tmp3)
+          local sa = tmp3._1
+          local tmp4 = tmp3._2
+          local sb = tmp4._1
+          local x = tmp4._2
           if x.__tag == "Some" then
-            local bez = g(sb)
+            local tmp5 = g(sb)
             local x0 = x[1]
-            if bez.__tag == "Skip" then
-              return Skip({ _1 = sa, _2 = { _1 = bez[1], _2 = Some(x0) } })
-            elseif bez.__tag == "Yield" then
-              local bfx = bez[1]
+            if tmp5.__tag == "Skip" then
+              return Skip({ _1 = sa, _2 = { _1 = tmp5[1], _2 = Some(x0) } })
+            elseif tmp5.__tag == "Yield" then
+              local tmp6 = tmp5[1]
               return Yield({
-                _1 = { _1 = x0, _2 = bfx._1 },
-                _2 = { _1 = sa, _2 = { _2 = None, _1 = bfx._2 } }
+                _1 = { _1 = x0, _2 = tmp6._1 },
+                _2 = { _1 = sa, _2 = { _2 = None, _1 = tmp6._2 } }
               })
-            elseif bez.__tag == "Done" then
+            elseif tmp5.__tag == "Done" then
               return Done
             end
           else
-            local beb = f(sa)
-            if beb.__tag == "Skip" then
-              return Skip({ _2 = { _1 = sb, _2 = None }, _1 = beb[1] })
-            elseif beb.__tag == "Yield" then
-              local bew = beb[1]
-              return Skip({ _1 = bew._2, _2 = { _1 = sb, _2 = Some(bew._1) } })
-            elseif beb.__tag == "Done" then
+            local tmp5 = f(sa)
+            if tmp5.__tag == "Skip" then
+              return Skip({ _2 = { _1 = sb, _2 = None }, _1 = tmp5[1] })
+            elseif tmp5.__tag == "Yield" then
+              local tmp6 = tmp5[1]
+              return Skip({ _1 = tmp6._2, _2 = { _1 = sb, _2 = Some(tmp6._1) } })
+            elseif tmp5.__tag == "Done" then
               return Done
             end
           end
@@ -49,7 +49,7 @@ do
       })
     end
   end
-  local bal = zip(Stream({
+  local tmp = zip(Stream({
     _1 = function(n)
       if n > 100 then
         return Done
@@ -66,18 +66,18 @@ do
     end,
     _2 = 100
   }))[1]
-  local go = bal._1
+  local go = tmp._1
   local function go0(ac, st)
-    local bam = go(st)
-    if bam.__tag == "Skip" then
-      return go0(ac, bam[1])
-    elseif bam.__tag == "Yield" then
-      local bab = bam[1]
-      local x = bab._1
-      return go0(x._1 + x._2 + ac, bab._2)
-    elseif bam.__tag == "Done" then
+    local tmp0 = go(st)
+    if tmp0.__tag == "Skip" then
+      return go0(ac, tmp0[1])
+    elseif tmp0.__tag == "Yield" then
+      local tmp1 = tmp0[1]
+      local x = tmp1._1
+      return go0(x._1 + x._2 + ac, tmp1._2)
+    elseif tmp0.__tag == "Done" then
       return ac
     end
   end
-  print(to_string(go0(0, bal._2)))
+  print(to_string(go0(0, tmp._2)))
 end

--- a/tests/lua/values_occ.lua
+++ b/tests/lua/values_occ.lua
@@ -3,15 +3,15 @@ do
   local print = print
   local to_string = tostring
   local function sum_squares(xs)
-    local jq = xs[1]
-    local go = jq._1
+    local tmp = xs[1]
+    local go = tmp._1
     return Stream({
       _1 = function(st)
-        local kk = go(st)
-        local x = kk._1
-        return { _2 = kk._2, _1 = x * x }
+        local tmp0 = go(st)
+        local x = tmp0._1
+        return { _2 = tmp0._2, _1 = x * x }
       end,
-      _2 = jq._2
+      _2 = tmp._2
     })
   end
   print(to_string(sum_squares))


### PR DESCRIPTION
`CoVar`'s name is now optional, meaning that we can differentiate between named variables and unnamed ones.

Currently this just means the backend will call variables `tmp` (or `tmp1`, etc...) instead of `cx`, etc... Hopefully this will lower churn when fresh name generation changes earlier down the pipeline. In the future, we might also try to improve the optimiser to try to preserve/propagate names when it can.

This also changes `Syntax.Desugar` to generate slightly better names for temporary variables.