### PR TITLE
Add idiom brackets

### DIFF
--- a/compiler/Errors.hs
+++ b/compiler/Errors.hs
@@ -70,6 +70,6 @@ highlightAmulet t =
 
     toStyle t
       | t >= TcArrow && t <= TcUnderscore = soperator
-      | t >= TcComma && t <= TcCSquare = soperator
+      | t >= TcComma && t <= TcCBanana = soperator
       | t >= TcLet && t <= TcAs = soperator
       | otherwise = id

--- a/examples/pipe.ml
+++ b/examples/pipe.ml
@@ -1,5 +1,5 @@
-let (<|) f x = f x
-let (|>) x f = f x
+let ( <| ) f x = f x
+let ( |> ) x f = f x
 
 let (>>) g f x = f (g x)
 let (<<) f g x = f (g x)

--- a/src/Core/Core.hs
+++ b/src/Core/Core.hs
@@ -219,7 +219,7 @@ instance (Annotation b, Pretty a) => Pretty (AnnTerm b a) where
     prettyRows :: [(Text, Type a, Atom a)] -> Doc
     prettyRows = hsep . punctuate comma . map (\(x, t, v) -> text x <+> colon <+> pretty t <+> equals <+> pretty v)
   pretty (AnnValues an xs) =
-    annotated an $ soperator (string "(|") <+> (hsep . punctuate comma . map pretty $ xs) <+> soperator (string "|)")
+    annotated an $ soperator (string "(#") <+> (hsep . punctuate comma . map pretty $ xs) <+> soperator (string "#)")
   pretty (AnnCast an a phi) = annotated an $ parens $ pretty a <+> soperator (string "|>") <+> pretty phi
 
 instance Pretty a => Pretty (Coercion a) where

--- a/src/Data/Reason.hs
+++ b/src/Data/Reason.hs
@@ -154,6 +154,7 @@ instance Respannable (Ann p) => Respannable (Expr p) where
   respan k (ListExp e a) = ListExp e (respan k a)
   respan k (ListComp e qs a) = ListComp e qs (respan k a)
   respan k (DoExpr v qs a) = DoExpr v qs (respan k a)
+  respan k (Idiom vp va es a) = Idiom vp va es (respan k a)
 
   respan k (Record fs a) = Record fs (respan k a)
   respan k (RecordExt f fs a) = RecordExt f fs (respan k a)

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -332,7 +332,7 @@ Atom :: { Expr Parsed }
      | hole                                   { withPos1 $1 (Hole (Name (getHole $1))) }
      | '_'                                    { withPos1 $1 (Hole (Name (T.singleton '_'))) }
      | begin List1(CompStmt, ExprSep) end     { withPos2 $1 $3 $ DoExpr bindVar $2 }
-     | '(|' ListE1(PreAtom) '|)'              { withPos2 $1 $3 $ Idiom pureVar apVar $2 }
+     | '(|' Expr0 ListE1(PreAtom) '|)'        { withPos2 $1 $4 $ Idiom pureVar apVar ($2:$3) }
      | '(' ')'                                { withPos2 $1 $2 $ Literal LiUnit }
      | '(' Section ')'                        { withPos2 $1 $3 $ Parens $2 }
      | '(' NullSection ',' List1(NullSection, ',') ')'

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -121,6 +121,8 @@ import Syntax
   ';'      { Token TcSemicolon _ _ }
   '('      { Token TcOParen _ _ }
   ')'      { Token TcCParen _ _ }
+  '(|'     { Token TcOBanana _ _ }
+  '|)'     { Token TcCBanana _ _ }
   '@'      { Token TcAt _ _ }
   '{'      { Token TcOBrace _ _ }
   '}'      { Token TcCBrace _ _ }
@@ -330,6 +332,7 @@ Atom :: { Expr Parsed }
      | hole                                   { withPos1 $1 (Hole (Name (getHole $1))) }
      | '_'                                    { withPos1 $1 (Hole (Name (T.singleton '_'))) }
      | begin List1(CompStmt, ExprSep) end     { withPos2 $1 $3 $ DoExpr bindVar $2 }
+     | '(|' ListE1(PreAtom) '|)'              { withPos2 $1 $3 $ Idiom pureVar apVar $2 }
      | '(' ')'                                { withPos2 $1 $2 $ Literal LiUnit }
      | '(' Section ')'                        { withPos2 $1 $3 $ Parens $2 }
      | '(' NullSection ',' List1(NullSection, ',') ')'
@@ -669,6 +672,8 @@ tuplePattern [x] a = case x of
 tuplePattern xs a = PTuple xs a
 
 bindVar = Name (T.pack ">>=")
+apVar = Name (T.pack "<*>")
+pureVar = Name (T.pack "pure")
 
 getIdent  (Token (TcOp x) _ _)         = x
 getIdent  (Token (TcIdentifier x) _ _) = x

--- a/src/Parser/Lexer.x
+++ b/src/Parser/Lexer.x
@@ -106,6 +106,8 @@ tokens :-
   <0> ":"      { constTok TcColon }
   <0> ";" ";"  { constTok TcTopSep }
   <0> ";"      { constTok TcSemicolon }
+  <0> "(" "|"  { constTok TcOBanana }
+  <0> "|" ")"  { constTok TcCBanana }
   <0> "("      { constTok TcOParen }
   <0> ")"      { constTok TcCParen }
   <0> "@"      { constTok TcAt }

--- a/src/Parser/Token.hs
+++ b/src/Parser/Token.hs
@@ -62,6 +62,8 @@ data TokenClass
   | TcBang -- ^ A @!@ token.
   | TcSemicolon -- ^ A @;@ token.
   | TcTopSep -- ^ A @;;@ token.
+  | TcOBanana -- ^ A @(|@ token.
+  | TcCBanana -- ^ A @|)@ token.
   | TcOParen -- ^ A @(@ token.
   | TcCParen -- ^ A @)@ token.
   | TcAt -- ^ A @@{@ token.
@@ -151,6 +153,8 @@ instance Show TokenClass where
   show TcCBrace = "}"
   show TcOSquare = "["
   show TcCSquare = "]"
+  show TcOBanana = "(|"
+  show TcCBanana = "|)"
 
   show (TcOp t) = unpack t
   show (TcIdentifier t) = unpack t

--- a/src/Syntax/Expr.hs
+++ b/src/Syntax/Expr.hs
@@ -92,6 +92,7 @@ data Expr p
   | ListComp (Expr p) [CompStmt p] (Ann p)
   -- Monads
   | DoExpr (Var p) [CompStmt p] (Ann p)
+  | Idiom (Var p) (Var p) [Expr p] (Ann p)
 
   | ExprWrapper (Wrapper p) (Expr p) (Ann p)
 

--- a/src/Syntax/Expr/Instances.hs
+++ b/src/Syntax/Expr/Instances.hs
@@ -52,6 +52,7 @@ instance Spanned (Ann p) => Spanned (Expr p) where
   annotation (ListExp _ a) = annotation a
   annotation (ListComp _ _ a) = annotation a
   annotation (DoExpr _ _ a) = annotation a
+  annotation (Idiom _ _ _ a) = annotation a
 
   annotation (ExprWrapper _ _ a) = annotation a
 
@@ -150,6 +151,7 @@ instance Pretty (Var p) => Pretty (Expr p) where
   pretty (ListExp es _) = brackets (hsep (punctuate comma (map pretty es)))
   pretty (ListComp e qs _) =
     brackets (pretty e <+> pipe <+> hsep (punctuate comma (map pretty qs)))
+  pretty (Idiom _ _ xs _) = "(|" <+> hsep (map parenArg xs) <+> "|)"
 
   pretty (ExprWrapper wrap ex an) = go wrap ex where
     go (TypeLam v t) ex =

--- a/src/Syntax/Let.hs
+++ b/src/Syntax/Let.hs
@@ -62,6 +62,7 @@ freeIn (RightSection a b _) = freeIn a <> freeIn b
 freeIn (BothSection b _) = freeIn b
 freeIn AccessSection{} = mempty
 freeIn (Vta e _ _) = freeIn e
+freeIn (Idiom vp va es _) = Set.fromList [vp, va] <> foldMap freeIn es
 freeIn (ListExp e _) = foldMap freeIn e
 freeIn (ListComp e qs _) = freeIn e <> freeInStmt qs
 freeIn (DoExpr v qs _) = freeInStmt qs <> bind where

--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -361,6 +361,9 @@ reExpr (ListComp e qs a) =
       go [] acc = ListComp <$> reExpr e <*> pure (reverse acc) <*> pure a
   in go qs []
 
+reExpr r@(Idiom vp va es a) = Idiom <$> lookupEx' vp <*> lookupEx' va <*> traverse reExpr es <*> pure a where
+  lookupEx' v = lookupEx v `catchJunk` r
+
 reExpr (DoExpr var qs a) =
   let go (CompGuard e:qs) acc flag = do
         e <- reExpr e

--- a/src/Syntax/Transform.hs
+++ b/src/Syntax/Transform.hs
@@ -104,6 +104,7 @@ transformExpr fe = goE where
   transE (ListExp e a) = ListExp (map goE e) a
   transE (ListComp e qs a) = ListComp (goE e) (map goQ qs) a
   transE (DoExpr v qs a) = DoExpr v (map goQ qs) a
+  transE (Idiom vp va es a) = Idiom vp va (map goE es) a
 
   goB (Binding v e c a) = Binding v (goE e) c a
   goB (TypedMatching v e a b) = TypedMatching v (goE e) a b
@@ -157,6 +158,7 @@ transformExprTyped fe fc ft = goE where
   transE (ListExp e a) = ListExp (map goE e) (goA a)
   transE (ListComp e qs a) = ListComp (transE e) (map goQ qs) (goA a)
   transE (DoExpr v qs a) = DoExpr v (map goQ qs) (goA a)
+  transE (Idiom vp va es a) = Idiom vp va (map goE es) (goA a)
 
   transBind (Binding v e b a) = Binding v (goE e) b (goA a)
   transBind (Matching p e a) = Matching (goP p) (goE e) (goA a)
@@ -241,5 +243,6 @@ correct ty (Lazy e a) = Lazy e (fst a, ty)
 correct ty (ListExp e a) = ListExp e (fst a, ty)
 correct ty (ListComp e qs a) = ListComp e qs (fst a, ty)
 correct ty (DoExpr v qs a) = DoExpr v qs (fst a, ty)
+correct ty (Idiom vp va es a) = Idiom vp va es (fst a, ty)
 
 correct ty (ExprWrapper w e a) = ExprWrapper w e (fst a, ty)

--- a/src/Syntax/Value.hs
+++ b/src/Syntax/Value.hs
@@ -39,6 +39,7 @@ value BothSection{} = True
 value AccessSection{} = True
 value (ListExp xs _) = all value xs
 value ListComp{} = False
+value Idiom{} = False
 value (OpenIn _ e _) = value e
 value (ExprWrapper _ e _) = value e
 value (DoExpr _ e _) =

--- a/src/Syntax/Verify.hs
+++ b/src/Syntax/Verify.hs
@@ -155,6 +155,7 @@ verifyExpr (Vta e _ _) = verifyExpr e
 verifyExpr (OpenIn _ e _) = verifyExpr e
 verifyExpr (ListExp e _) = traverse_ verifyExpr e
 verifyExpr (ListComp e qs _) = verifyExpr e *> traverse_ verifyCompStmt qs
+verifyExpr (Idiom _ _ es _) = traverse_ verifyExpr es
 verifyExpr (DoExpr _ qs _) = traverse_ verifyCompStmt qs
 verifyExpr (ExprWrapper w e a) =
   case w of
@@ -259,6 +260,7 @@ nonTrivial (Tuple es _) = any nonTrivial es
 nonTrivial (ListExp es _) = any nonTrivial es
 nonTrivial ListComp{} = False
 nonTrivial DoExpr{} = False
+nonTrivial Idiom{} = False
 nonTrivial TupleSection{} = False
 nonTrivial (OpenIn _ e _) = nonTrivial e
 nonTrivial Lazy{} = False

--- a/tests/lua/emit_ifs.ml
+++ b/tests/lua/emit_ifs.ml
@@ -6,7 +6,7 @@ let a && b = if a then b else false
 let a || b = if a then true else b
 let not a = if a then false else true
 
-let () = ignore { ands = (&&), ors = (||), not }
+let () = ignore { ands = (&&), ors = ( || ), not }
 
 let () = ignore @@ fun () ->
   if bool

--- a/tests/lua/list.lua
+++ b/tests/lua/list.lua
@@ -37,7 +37,7 @@ do
     local b = x + 1
     local function v(xss0)
       if xss0.__tag == "Cons" then
-        return { { _1 = { _1 = x, _2 = b }, _2 = v(xss0[1]._2) }, __tag = "Cons" }
+        return { { _2 = v(xss0[1]._2), _1 = { _1 = x, _2 = b } }, __tag = "Cons" }
       end
       return r(xs)
     end

--- a/tests/lua/stream-zip.ml
+++ b/tests/lua/stream-zip.ml
@@ -87,7 +87,7 @@ let zip (Stream (f, start)) (Stream (g, start')) =
         | Yield (y, sb') -> Yield ((x, y), sa, sb', None)
   Stream (go, start, start', None)
 
-let (|>) x f = f x
+let ( |> ) x f = f x
 let uncurry f (x, y) = f x y
 
 let (>>>) f g = fun x -> g (f x)

--- a/tests/lua/stream.ml
+++ b/tests/lua/stream.ml
@@ -30,7 +30,7 @@ let dump_stream e (Stream (f, start)) =
   io_write "["
   go start
 
-let (|>) x f = f x
+let ( |> ) x f = f x
 
 let main = range (1, 5) |> dump_stream to_string
 (* With `match` commuting conversion, this will do a single pass over the input

--- a/tests/parser/fail_pattern_guard.out
+++ b/tests/parser/fail_pattern_guard.out
@@ -1,5 +1,5 @@
 fail_pattern_guard.ml[2:10 ..2:11]: error
-  Unexpected ->, expected one of '_', let, fun, if, begin, true, false, match, function, lazy, '(', '{', '[', '!', identifier, constructor, qdotid, hole, int, float, string
+  Unexpected ->, expected one of '_', let, fun, if, begin, true, false, match, function, lazy, '(', '(|', '{', '[', '!', identifier, constructor, qdotid, hole, int, float, string
   │ 
 2 │ | x when -> ()
   │          ^^

--- a/tests/types/idioms.ml
+++ b/tests/types/idioms.ml
@@ -1,0 +1,4 @@
+let pure x = [x]
+let fs <*> xs = [ f x | with f <- fs, with x <- xs ]
+
+let cartesian xs ys = (| (,) xs ys |)

--- a/tests/types/idioms.out
+++ b/tests/types/idioms.out
@@ -1,0 +1,3 @@
+pure : Infer{'a : type}. 'a -> list 'a
+<*> : Infer{'a : type}. Infer{'b : type}. list ('b -> 'a) -> list 'b -> list 'a
+cartesian : Infer{'b : type}. Infer{'a : type}. list 'a -> list 'b -> list ('a * 'b)


### PR DESCRIPTION
`(| f x y z |)` = `pure f <*> x <*> y <*> z`; Like `begin`-expressions, uses whatever `pure` and `<*>` are in scope.