### PR TITLE
Switch the argument parser to be sub-command based

### DIFF
--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -110,7 +110,7 @@ data Command
     }
   deriving (Show)
 
-data Args
+newtype Args
   = Args
     { mainCommand :: Command
     }
@@ -130,8 +130,8 @@ argParser = info (args <**> helper <**> version)
 
     command' :: Parser Command
     command' =
-      ( hsubparser
-      $  command "compile"
+      hsubparser
+      (  command "compile"
          ( info compileCommand
          $ fullDesc <> progDesc "Compile an Amulet file to Lua.")
       <> command "repl"
@@ -145,7 +145,7 @@ argParser = info (args <**> helper <**> version)
     compileCommand :: Parser Command
     compileCommand = Compile
       <$> argument str (metavar "FILE" <> help "The file to compile.")
-      <*> optional ( option str $
+      <*> optional ( option str
            ( long "out" <> short 'o' <> metavar "FILE"
           <> help "Write the generated Lua to a specific file." ) )
       <*> option auto ( long "opt" <> short 'O' <> metavar "LEVEL" <> value 1 <> showDefault
@@ -197,16 +197,16 @@ main :: IO ()
 main = do
   options <- execParser argParser
   case options of
-    Args (Repl { toLoad, serverPort, options }) -> do
+    Args Repl { toLoad, serverPort, options } -> do
       extendPath (libraryPath options)
       replFrom serverPort (debugMode options) toLoad
-    Args (Connect { remoteCmd, serverPort }) -> runRemoteReplCommand serverPort remoteCmd
+    Args Connect { remoteCmd, serverPort } -> runRemoteReplCommand serverPort remoteCmd
 
-    Args (Compile { input, output = Just output }) | input == output -> do
+    Args Compile { input, output = Just output } | input == output -> do
       hPutStrLn stderr ("Cannot overwrite input file " ++ input)
       exitWith (ExitFailure 1)
 
-    Args (Compile { input, output, optLevel, options }) -> do
+    Args Compile { input, output, optLevel, options } -> do
       exists <- doesFileExist input
       if not exists
       then hPutStrLn stderr ("Cannot find input file " ++ input)

--- a/compiler/Main.hs
+++ b/compiler/Main.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE RankNTypes, OverloadedStrings, ScopedTypeVariables, FlexibleContexts, TemplateHaskell, CPP #-}
-module Main where
+{-# LANGUAGE RankNTypes, OverloadedStrings, ScopedTypeVariables, FlexibleContexts, TemplateHaskell, NamedFieldPuns #-}
+module Main(main) where
 
 import System.Exit (ExitCode(..), exitWith)
 import System.IO (hPutStrLn, stderr)
@@ -28,7 +28,6 @@ import Core.Core (Stmt)
 import Core.Var (CoVar)
 
 import Text.Pretty.Semantic hiding (empty)
-import Text.Pretty.Note
 
 import Frontend.Driver
 import Frontend.Errors
@@ -83,71 +82,119 @@ compileFromTo opt dbg file emit = do
 
 data DoOptimise = Do | Don't
 
-data CompilerOptions
-  = CompilerOptions
-    { debugMode   :: D.DebugMode
-    , forceRepl   :: Bool
-    , optLevel    :: Int
-    , replCommand :: Maybe String
-    , serverPort  :: Int
+data CompilerOptions = CompilerOptions
+  { debugMode   :: D.DebugMode
+  , libraryPath :: [String]
+  }
+  deriving (Show)
 
-    , input       :: Maybe FilePath
+data Command
+  = Compile
+    { input       :: FilePath
     , output      :: Maybe FilePath
+    , optLevel    :: Int
+    , options     :: CompilerOptions
+    }
+  | Repl
+    { toLoad      :: Maybe FilePath
+    , serverPort  :: Int
+    , options     :: CompilerOptions
+    }
+  | Connect
+    { remoteCmd   :: String
+    , serverPort  :: Int
     }
   deriving (Show)
 
-isError :: Note a b => a -> Bool
-isError x = diagnosticKind x == ErrorMessage
+data Args
+  = Args
+    { mainCommand :: Command
+    }
+  deriving (Show)
 
-flags :: ParserInfo CompilerOptions
-flags = flip info (fullDesc <> progDesc ("The Amulet compiler and REPL, version " ++ $(amcVersion))) . flip (<**>) helper $
-  CompilerOptions
-   <$> ( flag' D.Test   (long "test" <> short 't' <> help "Provides additional debug information on the output")
-     <|> flag' D.TestTc (long "test-tc"           <> help "Provides additional type check information on the output")
-     <|> pure D.Void )
+argParser :: ParserInfo Args
+argParser = info (args <**> helper <**> version)
+       $ fullDesc <> progDesc ("The Amulet compiler and REPL, version " ++ $(amcVersion))
+  where
+    version :: Parser (a -> a)
+    version
+      = infoOption $(amcVersion)
+      $ long "--version" <> short 'v' <> help "Show version information"
 
-   <*> switch ( long "repl" <> short 'r' <> help "Go to the REPL after loading each file" )
+    args :: Parser Args
+    args = Args <$> command'
 
-   <*> option auto ( long "opt" <> short 'O' <> metavar "LEVEL" <> value 1 <> help "Controls the optimisation level." )
+    command' :: Parser Command
+    command' =
+      ( hsubparser
+      $  command "compile"
+         ( info compileCommand
+         $ fullDesc <> progDesc "Compile an Amulet file to Lua.")
+      <> command "repl"
+         ( info replCommand
+         $ fullDesc <> progDesc "Launch the Amulet REPL." )
+      <> command "connect"
+         ( info connectCommand
+         $ fullDesc <> progDesc "Connect to an already running REPL instance." )
+      ) <|> pure (Repl Nothing defaultPort (CompilerOptions D.Void []))
 
-   <*> (Just <$>
-         option str
-         ( long "client" <> short 'c' <> metavar "COMMAND"
-        <> help "Connect to another running REPL to execute the command" )
-     <|> pure Nothing)
+    compileCommand :: Parser Command
+    compileCommand = Compile
+      <$> argument str (metavar "FILE" <> help "The file to compile.")
+      <*> optional ( option str $
+           ( long "out" <> short 'o' <> metavar "FILE"
+          <> help "Write the generated Lua to a specific file." ) )
+      <*> option auto ( long "opt" <> short 'O' <> metavar "LEVEL" <> value 1 <> showDefault
+                     <> help "Controls the optimisation level." )
+      <*> compilerOptions
 
-   <*> option auto ( long "port" <> metavar "PORT" <> value 5478 <> help "Port to use for the REPL server. (Default: 5478)" )
+    replCommand :: Parser Command
+    replCommand = Repl
+      <$> optional (argument str (metavar "FILE" <> help "A file to load into the REPL."))
+      <*> option auto ( long "port" <> metavar "PORT" <> value defaultPort <> showDefault
+                     <> help "Port to use for the REPL server." )
+      <*> compilerOptions
 
-   <*> (argument (Just <$> str) (metavar "FILE") <|> pure Nothing)
-   <*> (Just <$>
-         option str
-         ( long "out" <> short 'o' <> metavar "FILE"
-        <> help "Write the generated Lua to a specific file." )
-     <|> pure Nothing)
+    connectCommand :: Parser Command
+    connectCommand = Connect
+      <$> argument str (metavar "COMMAND" <> help "The command to run on the remote REPL.")
+      <*> option auto ( long "port" <> metavar "PORT" <> value defaultPort <> showDefault
+                     <> help "Port the remote REPL is hosted on." )
 
+    compilerOptions :: Parser CompilerOptions
+    compilerOptions = CompilerOptions
+      <$> ( flag' D.Test   (long "test" <> short 't' <> help "Provides additional debug information on the output")
+        <|> flag' D.TestTc (long "test-tc"           <> help "Provides additional type check information on the output")
+        <|> pure D.Void )
+      <*> pure []
+
+    optional :: Parser a -> Parser (Maybe a)
+    optional p = (Just <$> p) <|> pure Nothing
+
+    defaultPort :: Int
+    defaultPort = 5478
 
 main :: IO ()
 main = do
-  options <- execParser flags
+  options <- execParser argParser
   case options of
-    CompilerOptions { replCommand = Just str, serverPort = i } -> runRemoteReplCommand i str
-    CompilerOptions { debugMode = db, input = Nothing, serverPort = i } -> repl i db
-    CompilerOptions { debugMode = db, forceRepl = True, input = file, serverPort = i } -> replFrom i db file
+    Args (Repl { toLoad, serverPort, options }) -> replFrom serverPort (debugMode options) toLoad
+    Args (Connect { remoteCmd, serverPort }) -> runRemoteReplCommand serverPort remoteCmd
 
-    CompilerOptions { output = Just out, input = Just file }
-      | out == file -> do
-          hPutStrLn stderr ("Cannot overwrite input file " ++ out)
-          exitWith (ExitFailure 1)
+    Args (Compile { input, output = Just output }) | input == output -> do
+      hPutStrLn stderr ("Cannot overwrite input file " ++ input)
+      exitWith (ExitFailure 1)
 
-    -- CompilerOptions { debugMode = db, optLevel = opt, output = Nothing, input = Just file } | db /= D.Void -> do
-    --   let opt' = if opt >= 1 then Do else Don't
-    --   _ <- test opt' db file
-    --   pure ()
+    Args (Compile { input, output, optLevel, options }) -> do
+      exists <- doesFileExist input
+      if not exists
+      then hPutStrLn stderr ("Cannot find input file " ++ input)
+        >> exitWith (ExitFailure 1)
+      else pure ()
 
-    CompilerOptions { debugMode = db, optLevel = opt, output = out, input = Just file } -> do
-      let opt' = if opt >= 1 then Do else Don't
-          out' :: Pretty a => a -> IO ()
-          out' = case out of
+      let opt = if optLevel >= 1 then Do else Don't
+          writeOut :: Pretty a => a -> IO ()
+          writeOut = case output of
                    Nothing -> putDoc . pretty
                    Just f -> T.writeFile f . T.pack . show . pretty
-      compileFromTo opt' db file out'
+      compileFromTo opt (debugMode options) input writeOut

--- a/compiler/Repl.hs
+++ b/compiler/Repl.hs
@@ -635,4 +635,3 @@ wrapNamey m = do
   (res, name) <- runNameyT m =<< gets lastName
   modify (\s -> s { lastName = name })
   pure res
-


### PR DESCRIPTION
Effectively defines three sub-command: `compile`, `repl` and `connect` (defaulting to `repl`), rather than switching based on what combination of input files, `--repl` and `--client` were specified.

Hopefully this makes the `optparse-applicative` code a little easier to understand too.

<details>
<summary>Command overview</summary>

```
λ :main --help
Usage: <interactive> [COMMAND] [-v|--version]
  The Amulet compiler and REPL, version 0.4.0.0 (053fcfd)

Available options:
  -h,--help                Show this help text
  -v,--version             Show version information

Available commands:
  compile                  Compile an Amulet file to Lua.
  repl                     Launch the Amulet REPL.
  connect                  Connect to an already running REPL instance.
λ :main compile --help
Usage: <interactive> compile FILE [-o|--out FILE] [-O|--opt LEVEL] 
                             [(-t|--test) | --test-tc] [--lib ARG]
  Compile an Amulet file to Lua.

Available options:
  FILE                     The file to compile.
  -o,--out FILE            Write the generated Lua to a specific file.
  -O,--opt LEVEL           Controls the optimisation level. (default: 1)
  -t,--test                Provides additional debug information on the output
  --test-tc                Provides additional type check information on the
                           output
  --lib ARG                Add a folder to the library path
  -h,--help                Show this help text
λ :main repl --help
Usage: <interactive> repl [FILE] [--port PORT] [(-t|--test) | --test-tc] 
                          [--lib ARG]
  Launch the Amulet REPL.

Available options:
  FILE                     A file to load into the REPL.
  --port PORT              Port to use for the REPL server. (default: 5478)
  -t,--test                Provides additional debug information on the output
  --test-tc                Provides additional type check information on the
                           output
  --lib ARG                Add a folder to the library path
  -h,--help                Show this help text
λ :main connect --help
Usage: <interactive> connect COMMAND [--port PORT]
  Connect to an already running REPL instance.

Available options:
  COMMAND                  The command to run on the remote REPL.
  --port PORT              Port the remote REPL is hosted on. (default: 5478)
  -h,--help                Show this help text
```

<details>