### PR TITLE
A basic POC of Cram/Unified test format style tests

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -116,6 +116,7 @@ test-suite tests
                      , HUnit >= 1.6 && < 1.7
                      , tasty >= 1.0 && < 1.3
                      , these >= 1 && < 1.1
+                     , typed-process >= 0.2.6.0 && < 0.3
                      , amuletml
                      , filepath >= 1.4 && < 1.5
                      , hedgehog >= 1.0 && < 1.1
@@ -126,11 +127,16 @@ test-suite tests
                      , tasty-hedgehog >= 1.0 && < 1.1
                      , monad-chronicle >= 1 && < 1.1
                      , optparse-applicative >= 0.14 && < 0.16
-  other-modules:       Test.Golden
+                     , regex-base >= 0.94 && < 1.0
+                     , regex-pcre-builtin >= 0.95.1.1.8.43 && < 1.0
+  other-modules:       Test.Cram
+                     , Test.Golden
                      , Test.Reporter
                      , Test.Options
                      , Test.Rerun
                      , Test.Util
+
+                     , Test.Frontend.Amc
 
                      , Test.Core.Lint
                      , Test.Core.Backend

--- a/compiler/Test.hs
+++ b/compiler/Test.hs
@@ -19,11 +19,13 @@ import qualified Test.Syntax.Verify as Verify
 import qualified Test.Types.Check as TypesC
 import qualified Test.Core.Backend as Backend
 import qualified Test.Lua.Parser as LParser
+import qualified Test.Frontend.Amc as Amc
 
 tests :: IO TestTree
 tests = testGroup "Tests" <$> sequence
   [ pure (hedgehog Solver.tests)
 
+  , Amc.tests
   , Lint.tests
   , Lexer.tests
   , Parser.tests

--- a/compiler/Test/Cram.hs
+++ b/compiler/Test/Cram.hs
@@ -1,0 +1,163 @@
+{-# LANGUAGE OverloadedStrings, TupleSections, LambdaCase #-}
+{-| Support for CamM[1] tests within Tasty.
+
+  Cram tests allow writing a series of commands, along with their
+  expected outputs. They are effectively a golden test on an executable's
+  output, but gathered into a single file.
+
+  [1]: https://bitheap.org/cram/ -}
+module Test.Cram (cram, cramDir) where
+
+import Control.Monad
+
+import qualified Data.Text.Lazy.Builder as B
+import qualified Data.Text.Lazy.Encoding as L
+import qualified Data.Text.Lazy.IO as L
+import qualified Data.Text.Lazy as L
+import qualified Data.Text as T
+import Data.Algorithm.Diff
+import Data.Bifunctor
+import Data.Proxy
+import Data.Char
+
+import Text.Regex.Base.RegexLike
+import Text.Regex.PCRE.Text
+import Text.Printf (printf)
+
+import Test.Golden (Regenerate(..))
+import Test.Tasty.Providers
+import Test.Tasty.Options
+
+import System.Process.Typed
+import System.Directory
+import System.FilePath
+
+import Type.Reflection
+
+newtype CramTest = CramTest FilePath
+  deriving (Typeable)
+
+data TestStep
+  = Comment [T.Text]
+  | Command T.Text [OutputLine]
+
+-- | An expected output line, with text and expected pattern.
+type OutputLine = (T.Text, OutputKind)
+
+data OutputKind
+  = Plain
+  | Escaped T.Text
+  | Regex Regex
+
+-- | Escape any non-printable string
+escape :: T.Text -> T.Text
+escape = L.toStrict . B.toLazyText . T.foldr ((<>) . go) mempty where
+  go c | isPrint c = B.singleton c
+       | ord c <= 0xff = B.fromString (printf "\\x%02x" c)
+       | otherwise = B.fromString (printf "\\u%08x" c)
+
+-- | Determine if the expected output matches the actual one.
+matches :: OutputLine -> T.Text -> Bool
+matches (e, _) a | e == a = True
+matches (_, Plain) _ = False
+matches (_, Escaped e) a = e == escape a
+matches (_, Regex e) a = matchTest e a
+
+-- | Convert a string to an output line
+toOutput :: T.Text -> OutputLine
+toOutput t
+  | T.all isPrint t = (t, Plain)
+  | otherwise = (escape t <> "(esc)", Escaped (escape t))
+
+-- | Parse the current test
+parseTest :: L.Text -> Either String [TestStep]
+parseTest = go . zip [1..] . L.lines where
+  go :: [(Int, L.Text)] -> Either String [TestStep]
+  go [] = pure mempty
+  go ((n, l):ls)
+    | L.isPrefixOf "  $ " l = do
+      let (out, ls') = span (\(_, x) -> L.isPrefixOf "  " x && not (L.isPrefixOf "  $ " x)) ls
+          out' = traverse (uncurry goOut . second (L.toStrict . L.drop 2)) out
+      case out' of
+        Left msg -> Left msg
+        Right out' -> (Command (L.toStrict . L.drop 4 $ l) out':) <$> go ls'
+    | L.isPrefixOf "  " l = Left ("Unexpected command output on line " ++ show n)
+    | otherwise =
+      let (comments, ls') = span (not . L.isPrefixOf "  " . snd) ls
+      in (Comment (map (L.toStrict . snd) ((n, l):comments)):) <$> go ls'
+
+  goOut :: Int -> T.Text -> Either String OutputLine
+  goOut n l
+    | T.isSuffixOf "(esc)" l = pure (l, Escaped (T.dropEnd 5 l))
+    | T.isSuffixOf "(re)" l =
+        case makeRegexOptsM compAnchored execAnchored (T.dropEnd 4 l) of
+          Nothing -> Left ("Cannot compile regex on line " ++ show n)
+          Just re -> pure (l, Regex re)
+    | otherwise = pure (l, Plain)
+
+formatTest :: [TestStep] -> L.Text
+formatTest = B.toLazyText . go where
+  go :: [TestStep] -> B.Builder
+  go [] = mempty
+  go (Comment t:ts) =
+    foldr (\x b -> B.fromText x <> B.singleton '\n' <> b) (go ts) t
+  go (Command c out:ts) =
+    B.fromText "  $ " <> B.fromText c <> B.singleton '\n' <>
+    foldr (\(x, _) b -> B.fromText "  " <> B.fromText x <> B.singleton '\n' <> b)
+      (go ts) out
+
+-- | Run tests until the first failure. Returns a possible diff in the
+-- event of failures, and the "fixed" tests.
+runTest :: [TestStep] -> IO (Maybe (T.Text, [PolyDiff OutputLine T.Text]), [TestStep])
+runTest [] = pure (Nothing, [])
+runTest (c@Comment{}:ts) = second (c:) <$> runTest ts
+runTest (c@(Command command exp):ts) = do
+  actual <- T.lines . L.toStrict . L.decodeUtf8 . snd <$> readProcessInterleaved (shell (T.unpack command))
+  if check exp actual then second (c:) <$> runTest ts else
+    let diff = getDiffBy matches exp actual in
+    pure (Just (command, diff), Command command (ofDiff diff):ts)
+
+  where
+    check [] [] = True
+    check (_:_) [] = False
+    check [] (_:_) = False
+    check (e:es) (a:as) = matches e a && check es as
+
+    -- | Rebuild a list of output lines from a diff. The advantage here
+    -- is that we will preserve regexes and escaped lines which match.
+    ofDiff [] = []
+    ofDiff (Both l _:d) = l : ofDiff d
+    ofDiff (First _:d) = ofDiff d
+    ofDiff (Second l:d) = toOutput l : ofDiff d
+
+instance IsTest CramTest where
+  run options (CramTest input) _ = do
+    let Regenerate regenerate = lookupOption options
+    test <- parseTest <$> L.readFile input
+    case test of
+      Left err -> pure $ testFailed err
+      Right tests -> do
+        (errs, tests') <- runTest tests
+        case errs of
+          Nothing -> pure $ testPassed ""
+          Just (cmd, diff)-> do
+            when regenerate (L.writeFile input (formatTest tests'))
+            pure $ testFailed ("\27[0m $ " ++ T.unpack cmd ++ "\n" ++ T.unpack (formatDoc diff))
+
+    where
+      formatDoc :: [PolyDiff OutputLine T.Text] -> T.Text
+      formatDoc [] = ""
+      formatDoc (Both _ l:d)    =          " " <> l  <>       "\n" <> formatDoc d
+      formatDoc (First (l,_):d) = "\27[1;31m-" <> l  <> "\27[0m\n" <> formatDoc d
+      formatDoc (Second l:d)    = "\27[1;32m+" <> l' <> "\27[0m\n" <> formatDoc d
+        where (l', _) = toOutput l
+
+  testOptions = pure [ Option (Proxy :: Proxy Regenerate) ]
+
+-- | Construct a test from a single @.t@ file.
+cram :: FilePath -> TestTree
+cram name = singleTest name (CramTest name)
+
+-- | Construct multiple tests from a directory of @.t@ files.
+cramDir :: FilePath -> IO [TestTree]
+cramDir dir = map (cram . (dir</>)) . filter (isExtensionOf "t") <$> listDirectory dir

--- a/compiler/Test/Frontend/Amc.hs
+++ b/compiler/Test/Frontend/Amc.hs
@@ -1,0 +1,7 @@
+module Test.Frontend.Amc (tests) where
+
+import Test.Tasty
+import Test.Cram
+
+tests :: IO TestTree
+tests = testGroup "amc" <$> cramDir "tests/amc"

--- a/compiler/Test/Golden.hs
+++ b/compiler/Test/Golden.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings, MultiParamTypeClasses, FlexibleContexts, NamedFieldPuns #-}
 module Test.Golden
-  ( goldenFileM, goldenFile
+  ( Regenerate(..)
+  , goldenFileM, goldenFile
   , goldenDirOnM, goldenDirOn
   , goldenDirM, goldenDir
   ) where

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,8 @@ extra-deps:
   - monad-chronicle-1@sha256:94640ed9f2899a6143eb6ffe1fa3f26c8c6de2b873417501c77b74b326513815,1822
   - these-lens-1@sha256:960f53c44201f5f67d0158162ce39cc7095b958d584d76a2aead358a54c137d3,1138
   - ghc-lib-parser-8.8.0.20190723@sha256:34ffe7ca5e6ba21eb6bf2c118046e8891a9a79007eb3db48052124d3a7186bfd,8377
-# for amc-prove server:
+  - regex-pcre-builtin-0.95.1.1.8.43@sha256:2d671af361adf1776fde182a687bb6da022b1e5e3b0a064ce264289de63564a5,3088
+  # for amc-prove server:
   - http-kit-0.5.1
 
 flags:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -26,6 +26,13 @@ packages:
   original:
     hackage: ghc-lib-parser-8.8.0.20190723@sha256:34ffe7ca5e6ba21eb6bf2c118046e8891a9a79007eb3db48052124d3a7186bfd,8377
 - completed:
+    hackage: regex-pcre-builtin-0.95.1.1.8.43@sha256:2d671af361adf1776fde182a687bb6da022b1e5e3b0a064ce264289de63564a5,3088
+    pantry-tree:
+      size: 2587
+      sha256: 9224e37b215488b81a0fab0e8caa991010a4e053ba0e001de0b02c46a420622c
+  original:
+    hackage: regex-pcre-builtin-0.95.1.1.8.43@sha256:2d671af361adf1776fde182a687bb6da022b1e5e3b0a064ce264289de63564a5,3088
+- completed:
     hackage: http-kit-0.5.1@sha256:2c79d675df6836f3f07861475692ce757c47adcd2257af87246cf6b1e0efae1b,1989
     pantry-tree:
       size: 877

--- a/tests/amc/usage.t
+++ b/tests/amc/usage.t
@@ -1,0 +1,53 @@
+Using amc with the help flag displays all sub-command and the top-level options.
+
+  $ amc --help
+  Usage: amc [COMMAND] [-v|--version]
+    The Amulet compiler and REPL, version 0.4.0.0 \(\w+\)(re)
+  
+  Available options:
+    -h,--help                Show this help text
+    -v,--version             Show version information
+  
+  Available commands:
+    compile                  Compile an Amulet file to Lua.
+    repl                     Launch the Amulet REPL.
+    connect                  Connect to an already running REPL instance.
+
+Each sub-command can be run with --help too.
+
+  $ amc compile --help
+  Usage: amc compile FILE [-o|--out FILE] [-O|--opt LEVEL] 
+                     [(-t|--test) | --test-tc] [--lib ARG]
+    Compile an Amulet file to Lua.
+  
+  Available options:
+    FILE                     The file to compile.
+    -o,--out FILE            Write the generated Lua to a specific file.
+    -O,--opt LEVEL           Controls the optimisation level. (default: 1)
+    -t,--test                Provides additional debug information on the output
+    --test-tc                Provides additional type check information on the
+                             output
+    --lib ARG                Add a folder to the library path
+    -h,--help                Show this help text
+
+  $ amc repl --help
+  Usage: amc repl [FILE] [--port PORT] [(-t|--test) | --test-tc] [--lib ARG]
+    Launch the Amulet REPL.
+  
+  Available options:
+    FILE                     A file to load into the REPL.
+    --port PORT              Port to use for the REPL server. (default: 5478)
+    -t,--test                Provides additional debug information on the output
+    --test-tc                Provides additional type check information on the
+                             output
+    --lib ARG                Add a folder to the library path
+    -h,--help                Show this help text
+
+  $ amc connect --help
+  Usage: amc connect COMMAND [--port PORT]
+    Connect to an already running REPL instance.
+  
+  Available options:
+    COMMAND                  The command to run on the remote REPL.
+    --port PORT              Port the remote REPL is hosted on. (default: 5478)
+    -h,--help                Show this help text


### PR DESCRIPTION
I wanted to test running the actual compiler with some inputs, and so I did the only logical thing and wrote a test framework for it.

This effectively takes [Cram-style files](https://bitheap.org/cram/), runs the appropriate commands, and compares against the expected output. Like golden tests, it can be run with `-r` to regenerate the test files.

Right now I haven't implemented any serious tests for this - just running the `--help` page, which is obviously of dubious use. I probably want to extend the framework to also support running REPL commands in the future (I guess currently you could do this with `echo`/`cat`) and pipes, so we have a reliable way of ensuring REPL-specific bugs do not occur again.