### PR TITLE
Lower and Lint bug blitz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,5 @@ install:
 
 script:
 - stack --no-terminal build --fast --test --no-run-tests --ghc-options "-Werror -fmax-pmcheck-iterations=5000000"
-- env AMC_LIBRARY_PATH=$PWD/lib/ stack --no-terminal test --fast --ghc-options "-Werror -fmax-pmcheck-iterations=5000000" --test-arguments "--xml junit.xml --display t --hedgehog-tests 10000"
+- env AMC_LIBRARY_PATH=$PWD/lib/ stack --no-terminal test --fast --ghc-options "-Werror -fmax-pmcheck-iterations=5000000" --test-arguments "--xml junit.xml --display t --hedgehog-tests 10000 --timeout 30"
 - stack --no-terminal exec --package=hlint -- hlint --git

--- a/examples/mini-servant.ml
+++ b/examples/mini-servant.ml
@@ -86,7 +86,8 @@ let serve p h xs =
   | Some x -> x ()
 
 type api <- (p "hello" :> get string) <|> (p "echo" :> capture int :> get int)
-let handler = (fun () -> "hello, world!") :<|> (fun x () -> x)
+let handler : (unit -> string) * (int -> unit -> int) =
+  (fun () -> "hello, world!") :<|> (fun x () -> x)
 
 let x = serve (Proxy : proxy api) handler [ "hello" ]
 let y = serve (Proxy : proxy api) handler [ "echo", "123" ]

--- a/repl.sh
+++ b/repl.sh
@@ -47,5 +47,5 @@ export AMC_LIBRARY_PATH=$PWD/lib/:$AMC_LIBRARY_PATH
 
 exec stack exec -- \
   ghci -O0 -j2 +RTS -A128M -RTS ${WARN[@]} \
-  -i./src/:$out_dir/src/:./compiler/:./tools/ \
-  ./compiler/Main.hs "$@"
+  -i./src/:$out_dir/src/:./bin/ \
+  ./bin/Amc.hs "$@"

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -519,7 +519,7 @@ instance Pretty TypeError where
     vsep [ "This top-level binding can not have a polymorphic type because of the value restriction"
          , note <+> "It has type" <+> displayType tau
          , note <+> "But the variable" <+> vars
-         , bullet $ "Solution: give it a monomorphic type signature. For example:"
+         , bullet "Solution: give it a monomorphic type signature. For example:"
          , indent 4 (displayType (apply (Map.fromList (zip var_list (repeat tyUnit))) tau))
          ]
     where

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -124,6 +124,8 @@ data TypeError where
   DeadBranch :: TypeError -> TypeError
 
   AmbiguousType :: (Ord (Var p), Pretty (Var p)) => Var p -> Type p -> Set.Set (Var p) -> TypeError
+  ValueRestriction :: SomeReason -> Type Typed -> Set.Set (Var Typed) -> TypeError
+
   AmbiguousMethodTy :: (Ord (Var p), Pretty (Var p)) => Var p -> Type p -> Set.Set (Var p) -> TypeError
 
   UnsatClassCon :: SomeReason -> Constraint Typed -> WhyUnsat -> TypeError
@@ -512,6 +514,20 @@ instance Pretty TypeError where
     vsep [ "Invalid type in context for" <+> string what <+> "declaration:"
          , indent 4 (displayType ty)
          ]
+
+  pretty (ValueRestriction _ tau free) =
+    vsep [ "This top-level binding can not have a polymorphic type because of the value restriction"
+         , note <+> "It has type" <+> displayType tau
+         , note <+> "But the variable" <+> vars
+         , bullet $ "Solution: give it a monomorphic type signature. For example:"
+         , indent 4 (displayType (apply (Map.fromList (zip var_list (repeat tyUnit))) tau))
+         ]
+    where
+      var_list = Set.toList free
+      vars =
+        case var_list of
+          [x] -> pretty x <+> "needs to be determined"
+          xs -> hsep (map pretty xs) <+> "need to be determined"
 
   pretty (CanNotVta ty arg) =
     vsep [ "Can not apply expression of type" <+> displayType ty

--- a/src/Types/Infer/Class.hs
+++ b/src/Types/Infer/Class.hs
@@ -579,8 +579,8 @@ addArg _ _ ex = ex
 appArg :: Map.Map (Var Typed) (Type Typed) -> Type Typed -> Expr Typed -> Expr Typed
 appArg sub (TyPi (Invisible v _ _) rest) ex =
   case Map.lookup v sub of
-    Just x -> appArg sub rest $ ExprWrapper (TypeApp x) ex (annotation ex, rest)
-    Nothing -> appArg sub rest $ ExprWrapper (TypeApp TyType) ex (annotation ex, rest)
+    Just x -> appArg sub rest $ ExprWrapper (TypeApp x) ex (annotation ex, apply sub rest)
+    Nothing -> appArg sub rest $ ExprWrapper (TypeApp TyType) ex (annotation ex, apply sub rest)
 appArg _ _ ex = ex
 
 transplantPi :: Type Typed -> Type Typed -> Type Typed
@@ -602,7 +602,7 @@ reduceClassContext extra annot cons = do
         don't_skol <-
           case appsView con of
             TyCon v:args -> do
-              fds <- view (classDecs . at v) 
+              fds <- view (classDecs . at v)
               case fds of
                 Just (view ciFundep -> fds) ->
                   pure (foldMap (ftv . map (args !!)) (map (view _2) fds))

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -576,10 +576,10 @@ unify scope (TyArr l r) (TyApp (TyApp (TyCon v) l') r')
   | v == tyArrowName = ArrCo <$> unify scope l l' <*> unify scope r r'
 
 unify scope x@(TyApp f g) y@(TyArr l r) =
-  rethrow x y $ ArrCo <$> unify scope f (TyApp (TyCon tyArrowName) l) <*> unify scope g r
+  rethrow x y $ AppCo <$> unify scope f (TyApp (TyCon tyArrowName) l) <*> unify scope g r
 
 unify scope x@(TyArr l r) y@(TyApp f g) =
-  rethrow x y $ ArrCo <$> unify scope (TyApp (TyCon tyArrowName) l) f <*> unify scope r g
+  rethrow x y $ AppCo <$> unify scope (TyApp (TyCon tyArrowName) l) f <*> unify scope r g
 
 unify scope (TyArr a b) (TyArr a' b') = ArrCo <$> unify scope a a' <*> unify scope b b'
 unify scope (TyPi (Implicit a) b) (TyPi (Implicit a') b') =
@@ -653,9 +653,9 @@ unify scope (TyTuple l r) (TyApp (TyApp (TyCon v) l') r')
   | v == tyTupleName = ProdCo <$> unify scope l l' <*> unify scope r r'
 
 unify scope x@(TyApp f g) y@(TyTuple l r) =
-  rethrow x y $ ProdCo <$> unify scope f (TyApp (TyCon tyTupleName) l) <*> unify scope g r
+  rethrow x y $ AppCo <$> unify scope f (TyApp (TyCon tyTupleName) l) <*> unify scope g r
 unify scope x@(TyTuple l r) y@(TyApp f g) =
-  rethrow x y $ ProdCo <$> unify scope (TyApp (TyCon tyTupleName) l) f <*> unify scope r g
+  rethrow x y $ AppCo <$> unify scope (TyApp (TyCon tyTupleName) l) f <*> unify scope r g
 
 unify scope (TyOperator l v r) (TyTuple l' r')
   | v == tyTupleName = ProdCo <$> unify scope l l' <*> unify scope r r'

--- a/src/Types/Unify.hs
+++ b/src/Types/Unify.hs
@@ -968,7 +968,7 @@ subsumes' r scope ot@(TyTuple a b) nt@(TyTuple a' b') = do -- {{{
           Let
             [ TypedMatching
                 ( PTuple [ Capture elem (an, a), Capture elem' (an, b) ] (an, ot) )
-                ex (an, nt)
+                ex (an, ot)
                 [ (elem, a), (elem', b) ] ]
             ( Tuple [ ExprWrapper wa (VarRef elem (an, a)) (an, a')
                     , ExprWrapper wb (VarRef elem' (an, b)) (an, b') ]

--- a/tests/driver/Test/Types/Check.hs
+++ b/tests/driver/Test/Types/Check.hs
@@ -1,12 +1,15 @@
 module Test.Types.Check (tests) where
 
+import Test.Tasty.HUnit
 import Test.Util
 
 import Control.Monad.Infer (names, firstName)
+import Control.Monad.IO.Class
 import Control.Monad.Namey
 import Control.Lens ((^.), to, runIdentity)
 
 import qualified Data.Text.Lazy as L
+import qualified Data.Text.IO as T
 import qualified Data.Text as T
 import qualified Data.Map as Map
 
@@ -20,8 +23,14 @@ import Syntax.Desugar (desugarProgram)
 import Syntax.Types (difference, toMap)
 import Syntax.Builtin
 
+import Core.Lower
+import Core.Lint
+
+import System.Directory
+import System.FilePath
+
 import qualified Text.Pretty.Note as N
-import Text.Pretty.Semantic
+import Text.Pretty.Semantic hiding ((</>))
 
 result :: String -> T.Text -> T.Text
 result f c = runIdentity . flip evalNameyT firstName $ do
@@ -45,16 +54,40 @@ result f c = runIdentity . flip evalNameyT firstName $ do
 
     prettyErrs = vsep . map (N.format (N.fileSpans [(f, c)] N.defaultHighlight))
 
+checkLint :: String -> Assertion
+checkLint file = flip evalNameyT firstName $ do
+  c <- liftIO (T.readFile file)
+  let parsed = requireJust file c $ runParser file (L.fromStrict c) parseTops
+  ResolveResult resolved _ _ <- requireRight file c <$> runNullImport (resolveProgram builtinResolve parsed)
+
+  desugared <- desugarProgram resolved
+  inferred <- toEither <$> inferProgram builtinEnv desugared
+  case inferred of
+    Left _ -> pure ()
+    Right (prg, _) -> do
+      lowered <- runLowerT (lowerProg prg)
+      case runLintOK (checkStmt emptyScope lowered) of
+        Nothing -> pure ()
+        Just (_, es) -> liftIO $ assertFailure ("Core lint failed:\n" ++ T.unpack (displayDetailed (pretty es)))
+
 tests :: IO TestTree
 tests = do
-  inference <- testGroup "Type inference tests" <$> goldenDir result "tests/types/" ".ml"
-  gadts <- testGroup "GADT inference tests" <$> goldenDir result "tests/types/gadt/" ".ml"
-  rankn <- testGroup "Rank-N inference tests" <$> goldenDir result "tests/types/rankn/" ".ml"
-  lazy <- testGroup "Automatic laziness tests" <$> goldenDir result "tests/types/lazy/" ".ml"
-  letgen <- testGroup "Let generalization tests" <$> goldenDir result "tests/types/letgen/" ".ml"
-  wild <- testGroup "Type wildcard tests" <$> goldenDir result "tests/types/wildcards/" ".ml"
-  clss <- testGroup "Type class tests" <$> goldenDir result "tests/types/class/" ".ml"
-  vta <- testGroup "Visible type application tests" <$> goldenDir result "tests/types/vta/" ".ml"
-  syn <- testGroup "Type synonym tests " <$> goldenDir result "tests/types/synonym/" ".ml"
-  tyfun <- testGroup "Type function tests " <$> goldenDir result "tests/types/tyfun/" ".ml"
-  pure (testGroup "Type inference" [ inference, gadts, rankn, lazy, letgen, wild, clss, vta, syn, tyfun ])
+  golden <- traverse (\(group, dir) -> testGroup group <$> goldenDir result dir ".ml") groups
+  lint <- traverse makeLint groups
+  pure $ testGroup "Types" [ testGroup "Inference" golden, testGroup "Lint" lint ]
+  where
+    makeLint (group, dir) = do
+      files <- filter (isExtensionOf "ml") <$> listDirectory dir
+      pure $ testGroup group (map (\x -> testCase x (checkLint (dir </> x))) files)
+    groups =
+      [ ("Default tests", "tests/types/")
+      , ("GADT tests", "tests/types/gadt/")
+      , ("Rank-N tests", "tests/types/rankn/")
+      , ("Automatic laziness tests", "tests/types/lazy/")
+      , ("Let generalization tests", "tests/types/letgen/")
+      , ("Type wildcard tests", "tests/types/wildcards/")
+      , ("Type class tests", "tests/types/class/")
+      , ("Visible type application tests", "tests/types/vta/")
+      , ("Type synonym tests ", "tests/types/synonym/")
+      , ("Type function tests ", "tests/types/tyfun/")
+      ]

--- a/tests/lint/shadow_forall.ml
+++ b/tests/lint/shadow_forall.ml
@@ -8,4 +8,4 @@
 
 let foo : forall 'a. 'a -> forall 'b. 'b -> 'a = fun x y -> x
 
-let main = foo foo foo
+let main : int -> string -> int = foo foo foo

--- a/tests/lua/section.lua
+++ b/tests/lua/section.lua
@@ -3,8 +3,8 @@ do
   local main = {
     _1 = _plus0,
     _2 = {
-      _1 = function(tmp) return 2 * tmp end,
-      _2 = { _1 = function(r) return r / 2 end, _2 = function(tbl) return tbl.foo end }
+      _2 = { _1 = function(r) return r / 2 end, _2 = function(tbl) return tbl.foo end },
+      _1 = function(tmp) return 2 * tmp end
     }
   };
   (nil)(main)

--- a/tests/lua/section.ml
+++ b/tests/lua/section.ml
@@ -2,7 +2,7 @@ external val ( * ) : int -> int -> int = "function(x, y) return x * y end"
 external val ( + ) : int -> int -> int = "function(x, y) return x + y end"
 external val ( / ) : int -> int -> float = "function(x, y) return x / y end"
 (* Ensure that operator and record sections result in semi-sane code. *)
-let main = ( (+), (2*), (/2), (.foo) )
+let main = ( (+), (2*), (/2), ((.foo) : { foo : int } -> int) )
 
 external val ignore : 'a -> () = "nil"
 let () = ignore main

--- a/tests/types/begin05.ml
+++ b/tests/types/begin05.ml
@@ -5,7 +5,7 @@ end
 
 type identity 'a = Identity of 'a
 
-let _ = begin
+let _ : identity int = begin
   with x <- Identity 1
   2
 end

--- a/tests/types/begin05.out
+++ b/tests/types/begin05.out
@@ -4,10 +4,10 @@ begin05.ml[10:3 ..10:3]: error
    │   ^
   Couldn't match actual type int
     with the type expected by the context, identity 'b
-begin05.ml[8:5 ..8:5]: error
+begin05.ml[8:5 ..8:20]: error
   No instance for monad identity arising in the binding
   │ 
-8 │ let _ = begin
-  │     ^
+8 │ let _ : identity int = begin
+  │     ^^^^^^^^^^^^^^^^
   • Note: this constraint can not be quantified over
     because it is impossible to quantify over pattern bindings

--- a/tests/types/fail_value_restriction.ml
+++ b/tests/types/fail_value_restriction.ml
@@ -2,8 +2,8 @@ external val print : string -> unit = "print"
 
 type option 'a = None | Some of 'a
 
-let r = ref None
 
 let () =
+  let r = ref None
   r := Some 1
   print (!r)

--- a/tests/types/fail_value_restriction2.ml
+++ b/tests/types/fail_value_restriction2.ml
@@ -1,0 +1,3 @@
+let id x = x
+let f = id id
+let _ = f 0

--- a/tests/types/fail_value_restriction2.out
+++ b/tests/types/fail_value_restriction2.out
@@ -1,0 +1,9 @@
+fail_value_restriction2.ml[2:5 ..2:5]: error
+  │ 
+2 │ let f = id id
+  │     ^
+  This top-level binding can not have a polymorphic type because of the value restriction
+  • Note: It has type 'a -> 'a
+  • Note: But the variable a needs to be determined
+  • Solution: give it a monomorphic type signature. For example:
+      unit -> unit

--- a/tests/types/unify.ml
+++ b/tests/types/unify.ml
@@ -6,4 +6,4 @@ type m1 'f 'a = M1 of 'f 'a
 
 let f x = M1 (L1 (M1 (K1 x)))
 
-let _ = f 123
+let _ : m1 (sum (m1 (k1 int)) int) () = f 123


### PR DESCRIPTION
I recently found a couple of code examples which really should have failed core lint, but didn't. Attempting to fix that yielded something more worrying: we have several TC tests which don't pass core lint currently, including two which don't appear to terminate.

This is a (painful) attempt at trying to squash those bugs, and hopefully get core lint in a more robust shape.

## Currently failing tests
 - [x] `rankn/tuple01-pass.ml` - `Types.Unify` was generating an incorrect annotation. Sorry!
 - [x] `product.ml`, `arrow.ml`: Broken lowering of `(->)` type operator:
   ```
   Expected type ->#t-7 (int#t-2 -> int#t-2) -> {_1 : int#t-2, _2 : int#t-2} -> {_1 : int#t-2, _2 : int#t-2}
        got type (int#t-2 -> int#t-2) -> {_1 : int#t-2, _2 : int#t-2} -> {_1 : int#t-2, _2 : int#t-2}
 - [x] `class/type-sk.ml`, `class/n-queens.ml` - These time out after 30 seconds - not sure if actually non-terminating, or if lint/lower is very inefficient.

## Other notes
 - [ ] `uni` (and so `apart`) are currently using `uniOpen`. This is incorrect - they should be using `uniClosed` instead. I believe this change was made to ease the development of features early on in the process, but currently it is masking genuine bugs.