### PR TITLE
Tiny module-system and CLI improvements

### DIFF
--- a/bin/Amc.hs
+++ b/bin/Amc.hs
@@ -186,7 +186,9 @@ argParser = info (args <**> helper <**> version)
         <|> flag' D.TestTc (long "test-tc"           <> hidden <> help "Provides additional type check information on the output")
         <|> pure D.Void )
       <*> many (option str (long "lib" <> help "Add a folder to the library path"))
-      <*> switch (long "core-lint" <> hidden <> help "Verify that Amulet's intermediate representation is well-formed.")
+      <*> switch ( long "core-lint" <> hidden
+                 <> help ( "Verify that Amulet's intermediate representation is well-formed. This is an internal debugging flag, "
+                        ++ "and should only be used if you suspect there is a bug in Amulet." ) )
 
     optional :: Parser a -> Parser (Maybe a)
     optional p = (Just <$> p) <|> pure Nothing

--- a/bin/GenExample.hs
+++ b/bin/GenExample.hs
@@ -27,9 +27,10 @@ main :: IO ()
 main = do
   [file] <- getArgs
 
+  driver <- makeDriver
   (((core, errors), driver), _) <-
       flip runNameyT firstName
-    . flip runStateT emptyDriver
+    . flip runStateT driver
     $ compile file
 
   x <- T.readFile file

--- a/src/Control/Monad/Infer.hs
+++ b/src/Control/Monad/Infer.hs
@@ -320,7 +320,7 @@ instance Pretty TypeError where
       describe TyType = "type constructor"
       describe _ = "function"
 
-  pretty (NotInScope e) = string "Variable not in scope:" <+> pretty e
+  pretty (NotInScope e) = string "INTERNAL TC ERROR: Variable not in scope:" <+> pretty e
   pretty (ArisingFrom er _) = pretty er
 
   pretty (CustomTypeError e) = e

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -18,36 +18,33 @@ import Core.Lint
 import Control.Monad.Namey
 import Control.Monad
 
-lintPasses :: Bool
-lintPasses = True
-
-optmOnce :: forall m. Monad m => [Stmt CoVar] -> NameyT m [Stmt CoVar]
-optmOnce = passes where
+optmOnce :: forall m. Monad m => Bool -> [Stmt CoVar] -> NameyT m [Stmt CoVar]
+optmOnce lint = passes where
   passes :: [Stmt CoVar] -> NameyT m [Stmt CoVar]
   passes = foldr1 (>=>)
-           [ linted "Reduce" reducePass
-           , linted "Dead code" $ pure . deadCodePass
-           , linted "Uncurry" uncurryPass
+           [ linting "Ringuce" reducePass
+           , linting "Dead code" $ pure . deadCodePass
+           , linting "Uncurry" uncurryPass
 
-           , linted "Sinking" $ pure . sinkingPass . tagFreeSet
+           , linting "Sinking" $ pure . sinkingPass . tagFreeSet
 
-           , linted "CSE" (pure . csePass)
-           , linted "Reduce #2" reducePass
+           , linting "CSE" (pure . csePass)
+           , linting "Ringuce #2" reducePass
            ]
+  linting = if lint then linted else flip const
 
 linted :: Monad f => String -> ([Stmt CoVar] -> f [Stmt CoVar]) -> [Stmt CoVar] -> f [Stmt CoVar]
-linted pass fn
-  | lintPasses
-  = fmap (runLint pass =<< checkStmt emptyScope) . fn
-  | otherwise = fn
+linted pass fn = fmap (runLint pass =<< checkStmt emptyScope) . fn
 
 -- | Run the optimiser multiple times over the input core.
-optimise :: forall m. Monad m => [Stmt CoVar] -> NameyT m [Stmt CoVar]
-optimise = go 10 <=< prepasses . if lintPasses then runLint "Lower" =<< checkStmt emptyScope else id where
+optimise :: forall m. Monad m => Bool -> [Stmt CoVar] -> NameyT m [Stmt CoVar]
+optimise lint = go 10 <=< prepasses <=< linting "Lower" pure where
   go :: Integer -> [Stmt CoVar] -> NameyT m [Stmt CoVar]
   go k sts
-    | k > 0 = go (k - 1) =<< optmOnce sts
+    | k > 0 = go (k - 1) =<< optmOnce lint sts
     | otherwise = pure sts
 
   prepasses :: [Stmt CoVar] -> NameyT m [Stmt CoVar]
-  prepasses = linted "Newtype" killNewtypePass
+  prepasses = linting "Newtype" killNewtypePass
+
+  linting = if lint then linted else flip const

--- a/src/Core/Simplify.hs
+++ b/src/Core/Simplify.hs
@@ -22,14 +22,14 @@ optmOnce :: forall m. Monad m => Bool -> [Stmt CoVar] -> NameyT m [Stmt CoVar]
 optmOnce lint = passes where
   passes :: [Stmt CoVar] -> NameyT m [Stmt CoVar]
   passes = foldr1 (>=>)
-           [ linting "Ringuce" reducePass
+           [ linting "Reduce" reducePass
            , linting "Dead code" $ pure . deadCodePass
            , linting "Uncurry" uncurryPass
 
            , linting "Sinking" $ pure . sinkingPass . tagFreeSet
 
            , linting "CSE" (pure . csePass)
-           , linting "Ringuce #2" reducePass
+           , linting "Reduce #2" reducePass
            ]
   linting = if lint then linted else flip const
 

--- a/tests/amc/files/import.ml
+++ b/tests/amc/files/import.ml
@@ -1,0 +1,3 @@
+open import "my_lib.ml"
+
+let () = my_fun ()

--- a/tests/amc/files/use_prelude.ml
+++ b/tests/amc/files/use_prelude.ml
@@ -1,1 +1,0 @@
-let () = print "Test"

--- a/tests/amc/files/use_prelude.ml
+++ b/tests/amc/files/use_prelude.ml
@@ -1,0 +1,1 @@
+let () = print "Test"

--- a/tests/amc/lib/my_lib.ml
+++ b/tests/amc/lib/my_lib.ml
@@ -1,0 +1,1 @@
+let my_fun x = x

--- a/tests/amc/lib/prelude.ml
+++ b/tests/amc/lib/prelude.ml
@@ -1,0 +1,1 @@
+external val print : string -> unit = "error"

--- a/tests/amc/path.t
+++ b/tests/amc/path.t
@@ -1,0 +1,15 @@
+amc compile will extend the compile path
+
+  $ amc compile tests/amc/files/import.ml
+  tests/amc/files/import.ml[1:6 ..1:23]: error
+    Cannot resolve "my_lib.ml"
+  
+    Arising from use of the module
+    │ 
+  1 │ open import "my_lib.ml"
+    │      ^^^^^^^^^^^^^^^^^^
+
+  $ amc compile --lib tests/amc/lib tests/amc/files/import.ml
+  do
+  
+  end

--- a/tests/amc/prelude.t
+++ b/tests/amc/prelude.t
@@ -1,0 +1,42 @@
+amc compile can change the prelude
+
+  $ amc compile tests/amc/files/use_prelude.ml
+  do
+    local print = print
+    print("Test")
+  end
+
+Not using the prelude will fail
+
+  $ amc compile --no-prelude tests/amc/files/use_prelude.ml
+  tests/amc/files/use_prelude.ml[1:10 ..1:14]: error
+    Variable not in scope: `print`
+  
+    Arising from use of the expression
+    │ 
+  1 │ let () = print "Test"
+    │          ^^^^^
+
+One can use a custom prelude
+
+  $ amc compile --prelude=tests/amc/lib/prelude.ml tests/amc/files/use_prelude.ml
+  do
+    local print = error
+    print("Test")
+  end
+
+Prelude is found from the library path
+
+  $ amc compile --lib=tests/amc/lib tests/amc/files/use_prelude.ml
+  do
+    local print = error
+    print("Test")
+  end
+
+Prelude also works within the REPL
+
+  $ echo 'print "Hello"' | amc repl
+  Listening on port 5478
+  > Hello
+  _ = ()
+  > 

--- a/tests/amc/prelude.t
+++ b/tests/amc/prelude.t
@@ -1,42 +1,34 @@
-amc compile can change the prelude
-
-  $ amc compile tests/amc/files/use_prelude.ml
-  do
-    local print = print
-    print("Test")
-  end
-
-Not using the prelude will fail
-
-  $ amc compile --no-prelude tests/amc/files/use_prelude.ml
-  tests/amc/files/use_prelude.ml[1:10 ..1:14]: error
-    Variable not in scope: `print`
-  
-    Arising from use of the expression
-    │ 
-  1 │ let () = print "Test"
-    │          ^^^^^
-
-One can use a custom prelude
-
-  $ amc compile --prelude=tests/amc/lib/prelude.ml tests/amc/files/use_prelude.ml
-  do
-    local print = error
-    print("Test")
-  end
-
-Prelude is found from the library path
-
-  $ amc compile --lib=tests/amc/lib tests/amc/files/use_prelude.ml
-  do
-    local print = error
-    print("Test")
-  end
-
-Prelude also works within the REPL
+Repl will be launched with the prelude
 
   $ echo 'print "Hello"' | amc repl
   Listening on port 5478
   > Hello
   _ = ()
+  > 
+
+Not using the prelude will fail
+
+  $ echo 'print "Hello"' | amc repl --no-prelude
+  Listening on port 5478
+  > =stdin[1:1 ..1:5]: error
+    Variable not in scope: `print`
+  
+    Arising from use of the expression
+    │ 
+  1 │ print "Hello"
+    │ ^^^^^
+  > 
+
+One can use a custom prelude
+
+  $ echo 'print "Hello"' | amc repl --prelude=tests/amc/lib/prelude.ml
+  Listening on port 5478
+  > =stdin:2: Hello
+  > 
+
+Prelude is found from the library path
+
+  $ echo 'print "Hello"' | amc repl --lib=tests/amc/lib
+  Listening on port 5478
+  > =stdin:2: Hello
   > 

--- a/tests/amc/usage.t
+++ b/tests/amc/usage.t
@@ -23,12 +23,12 @@ Each sub-command can be run with --help too.
     FILE                     The file to compile.
     -o,--out FILE            Write the generated Lua to a specific file.
     -O,--opt LEVEL           Controls the optimisation level. (default: 1)
-    --core-lint              Verified that Amulet's intermediate representation is
-                             well-formed.
     -t,--test                Provides additional debug information on the output
     --test-tc                Provides additional type check information on the
                              output
     --lib ARG                Add a folder to the library path
+    --core-lint              Verified that Amulet's intermediate representation is
+                             well-formed.
     -h,--help                Show this help text
 
   $ amc repl --help
@@ -44,6 +44,8 @@ Each sub-command can be run with --help too.
     --test-tc                Provides additional type check information on the
                              output
     --lib ARG                Add a folder to the library path
+    --core-lint              Verified that Amulet's intermediate representation is
+                             well-formed.
     -h,--help                Show this help text
 
   $ amc connect --help

--- a/tests/amc/usage.t
+++ b/tests/amc/usage.t
@@ -28,7 +28,9 @@ Each sub-command can be run with --help too.
                              output
     --lib ARG                Add a folder to the library path
     --core-lint              Verify that Amulet's intermediate representation is
-                             well-formed.
+                             well-formed. This is an internal debugging flag, and
+                             should only be used if you suspect there is a bug in
+                             Amulet.
     -h,--help                Show this help text
 
   $ amc repl --help
@@ -45,7 +47,9 @@ Each sub-command can be run with --help too.
                              output
     --lib ARG                Add a folder to the library path
     --core-lint              Verify that Amulet's intermediate representation is
-                             well-formed.
+                             well-formed. This is an internal debugging flag, and
+                             should only be used if you suspect there is a bug in
+                             Amulet.
     -h,--help                Show this help text
 
   $ amc connect --help

--- a/tests/amc/usage.t
+++ b/tests/amc/usage.t
@@ -17,7 +17,7 @@ Each sub-command can be run with --help too.
 
   $ amc compile --help
   Usage: amc compile FILE [-o|--out FILE] [-O|--opt LEVEL] 
-                     [(-t|--test) | --test-tc] [--lib ARG]
+                     [(-t|--test) | --test-tc] [--lib ARG] [--core-lint]
     Compile an Amulet file to Lua.
   
   Available options:
@@ -28,6 +28,8 @@ Each sub-command can be run with --help too.
     --test-tc                Provides additional type check information on the
                              output
     --lib ARG                Add a folder to the library path
+    --core-lint              Verified that Amulet's intermediate representation is
+                             well-formed.
     -h,--help                Show this help text
 
   $ amc repl --help

--- a/tests/amc/usage.t
+++ b/tests/amc/usage.t
@@ -17,7 +17,8 @@ Each sub-command can be run with --help too.
 
   $ amc compile --help
   Usage: amc compile FILE [-o|--out FILE] [-O|--opt LEVEL] 
-                     [(-t|--test) | --test-tc] [--lib ARG] [--core-lint]
+                     [(-t|--test) | --test-tc] [--lib ARG] 
+                     [--no-prelude | --prelude PATH] [--core-lint]
     Compile an Amulet file to Lua.
   
   Available options:
@@ -28,12 +29,15 @@ Each sub-command can be run with --help too.
     --test-tc                Provides additional type check information on the
                              output
     --lib ARG                Add a folder to the library path
+    --no-prelude             Do not load files with a prelude.
+    --prelude PATH           Specify a custom prelude to use.
     --core-lint              Verified that Amulet's intermediate representation is
                              well-formed.
     -h,--help                Show this help text
 
   $ amc repl --help
-  Usage: amc repl [FILE] [--port PORT] [(-t|--test) | --test-tc] [--lib ARG]
+  Usage: amc repl [FILE] [--port PORT] [(-t|--test) | --test-tc] [--lib ARG] 
+                  [--no-prelude | --prelude PATH]
     Launch the Amulet REPL.
   
   Available options:
@@ -43,6 +47,8 @@ Each sub-command can be run with --help too.
     --test-tc                Provides additional type check information on the
                              output
     --lib ARG                Add a folder to the library path
+    --no-prelude             Do not load files with a prelude.
+    --prelude PATH           Specify a custom prelude to use.
     -h,--help                Show this help text
 
   $ amc connect --help

--- a/tests/amc/usage.t
+++ b/tests/amc/usage.t
@@ -27,7 +27,7 @@ Each sub-command can be run with --help too.
     --test-tc                Provides additional type check information on the
                              output
     --lib ARG                Add a folder to the library path
-    --core-lint              Verified that Amulet's intermediate representation is
+    --core-lint              Verify that Amulet's intermediate representation is
                              well-formed.
     -h,--help                Show this help text
 
@@ -44,7 +44,7 @@ Each sub-command can be run with --help too.
     --test-tc                Provides additional type check information on the
                              output
     --lib ARG                Add a folder to the library path
-    --core-lint              Verified that Amulet's intermediate representation is
+    --core-lint              Verify that Amulet's intermediate representation is
                              well-formed.
     -h,--help                Show this help text
 

--- a/tests/amc/usage.t
+++ b/tests/amc/usage.t
@@ -16,39 +16,34 @@ Using amc with the help flag displays all sub-command and the top-level options.
 Each sub-command can be run with --help too.
 
   $ amc compile --help
-  Usage: amc compile FILE [-o|--out FILE] [-O|--opt LEVEL] 
-                     [(-t|--test) | --test-tc] [--lib ARG] 
-                     [--no-prelude | --prelude PATH] [--core-lint]
+  Usage: amc compile FILE [-o|--out FILE] [-O|--opt LEVEL] [--lib ARG]
     Compile an Amulet file to Lua.
   
   Available options:
     FILE                     The file to compile.
     -o,--out FILE            Write the generated Lua to a specific file.
     -O,--opt LEVEL           Controls the optimisation level. (default: 1)
+    --core-lint              Verified that Amulet's intermediate representation is
+                             well-formed.
     -t,--test                Provides additional debug information on the output
     --test-tc                Provides additional type check information on the
                              output
     --lib ARG                Add a folder to the library path
-    --no-prelude             Do not load files with a prelude.
-    --prelude PATH           Specify a custom prelude to use.
-    --core-lint              Verified that Amulet's intermediate representation is
-                             well-formed.
     -h,--help                Show this help text
 
   $ amc repl --help
-  Usage: amc repl [FILE] [--port PORT] [(-t|--test) | --test-tc] [--lib ARG] 
-                  [--no-prelude | --prelude PATH]
+  Usage: amc repl [FILE] [--port PORT] [--no-prelude | --prelude PATH] [--lib ARG]
     Launch the Amulet REPL.
   
   Available options:
     FILE                     A file to load into the REPL.
     --port PORT              Port to use for the REPL server. (default: 5478)
+    --no-prelude             Do not load files with a prelude.
+    --prelude PATH           Specify a custom prelude to use.
     -t,--test                Provides additional debug information on the output
     --test-tc                Provides additional type check information on the
                              output
     --lib ARG                Add a folder to the library path
-    --no-prelude             Do not load files with a prelude.
-    --prelude PATH           Specify a custom prelude to use.
     -h,--help                Show this help text
 
   $ amc connect --help

--- a/tests/driver/Test/Core/Backend.hs
+++ b/tests/driver/Test/Core/Backend.hs
@@ -42,7 +42,7 @@ result o f c = fst . flip runNamey firstName $ do
   lower <- runLowerT (lowerProg inferred)
   compiled <-
     if o
-    then compileProgram <$> optimise lower
+    then compileProgram <$> optimise True lower
     else pure . LuaDo . toList . fst
        . uncurry addBuiltins
        . flip runState defaultEmitState . emitStmt

--- a/tests/driver/Test/Core/Lint.hs
+++ b/tests/driver/Test/Core/Lint.hs
@@ -81,7 +81,7 @@ testLint f file = do
 
 testLintLower, testLintSimplify :: String -> Assertion
 testLintLower = testLint pure
-testLintSimplify = testLint optimise
+testLintSimplify = testLint (optimise True)
 
 tests :: IO TestTree
 tests = do

--- a/tests/driver/Test/Syntax/Resolve.hs
+++ b/tests/driver/Test/Syntax/Resolve.hs
@@ -22,21 +22,20 @@ import Frontend.Driver
 import Frontend.Errors
 
 result :: String -> T.Text -> IO T.Text
-result file contents
-  = flip evalNameyT firstName
-  . flip evalStateT emptyDriver
-  $ do
-  let parsed = requireJust file contents $ runParser file (L.fromStrict contents) parseTops
-  (resolved, errors) <- resolve "tests/resolve" parsed
+result file contents = do
+  driver <- makeDriver
+  flip evalNameyT firstName . flip evalStateT driver $ do
+    let parsed = requireJust file contents $ runParser file (L.fromStrict contents) parseTops
+    (resolved, errors) <- resolve "tests/resolve" parsed
 
-  files <- ((file, contents):) <$> (fileMap =<< get)
-  let fmt :: N.Note a Style => [a] -> [N.NoteDoc Style]
-      fmt = map (N.format (N.fileSpans files N.defaultHighlight))
-  pure . displayPlainVerbose . vsep . concat $
-    [ maybe [] (pure . fmap Right . pretty . program) resolved
-    , fmt (errors ^. parseErrors)
-    , fmt (errors ^. resolveErrors)
-    ]
+    files <- ((file, contents):) <$> (fileMap =<< get)
+    let fmt :: N.Note a Style => [a] -> [N.NoteDoc Style]
+        fmt = map (N.format (N.fileSpans files N.defaultHighlight))
+    pure . displayPlainVerbose . vsep . concat $
+      [ maybe [] (pure . fmap Right . pretty . program) resolved
+      , fmt (errors ^. parseErrors)
+      , fmt (errors ^. resolveErrors)
+      ]
 
 tests :: IO TestTree
 tests = testGroup "Tests.Syntax.Resolve" <$> goldenDirM result "tests/resolve/" ".ml"

--- a/tests/driver/Test/Types/Check.hs
+++ b/tests/driver/Test/Types/Check.hs
@@ -76,7 +76,7 @@ checkLint optm file = flip evalNameyT firstName $ do
         Nothing -> pure ()
         Just (_, es) -> liftIO $ assertFailure ("Core lint failed:\n" ++ T.unpack (displayDetailed (pretty es)))
       -- Optimise runs lower by default
-      when optm (optimise lowered $> ())
+      when optm (optimise True lowered $> ())
 
 tests :: IO TestTree
 tests = do


### PR DESCRIPTION
 - Disable core lint by default, requiring users to run with `--core-lint` instead.
 - Allow running starting the REPL with a custom prelude (`--prelude`) or no prelude (`--no-prelude`). 
 - Move library paths to a "driver config", rather than extending an environment variable.