### PR TITLE
Module caching

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -176,11 +176,13 @@ library
                      , filepath >= 1.4 && < 1.5
                      , hashable >= 1.2 && < 1.4
                      , directory >= 1.3 && < 1.4
+                     , bytestring >= 0.10 && < 0.11
                      , containers >= 0.5 && < 0.7
                      , these-lens >= 1 && < 1.1
                      , transformers >= 0.5 && < 0.6
                      , monad-chronicle >= 1 && < 1.1
                      , template-haskell >= 2.13 && < 2.16
+                     , cryptohash-sha256 >= 0.11 && < 0.12
                      , annotated-wl-pprint >= 0.7 && < 0.8
                      , unordered-containers >= 0.2 && < 0.3
                      , logict >= 0.7 && < 0.8

--- a/bin/Amc.hs
+++ b/bin/Amc.hs
@@ -53,7 +53,7 @@ runCompile opt (DoLint lint) dconfig file = do
       flip runNameyT firstName
     . flip runStateT (D.makeDriverWith dconfig)
     $ do
-      (core, errors) <- D.compile path
+      (core, errors) <- D.compiles path
       ~(Just env) <- D.getTypeEnv path
       pure (env, core, errors)
 

--- a/bin/Amc/Repl.hs
+++ b/bin/Amc/Repl.hs
@@ -119,16 +119,27 @@ defaultState config = do
     { resolveScope = Bi.builtinResolve
     , inferScope   = Bi.builtinEnv
     , emitState    = B.defaultEmitState
-    , lastName     = S.TgName (T.pack "a") 1
     , lowerState   = L.defaultState
-
     , luaState     = state
 
+    , lastName     = S.TgName (T.pack "a") 1
     , driver       = D.makeDriverWith (driverConfig config)
     , config       = config
 
     , currentFile  = Nothing
     , outputHandle = stdout
+    }
+
+resetState :: ReplState -> IO ReplState
+resetState state = do
+  lState <- L.newstate
+  L.runWith lState L.openlibs
+  pure state
+    { resolveScope = Bi.builtinResolve
+    , inferScope   = Bi.builtinEnv
+    , emitState    = B.defaultEmitState
+    , lowerState   = L.defaultState
+    , luaState     = lState
     }
 
 type Listener = Maybe ThreadId
@@ -212,15 +223,11 @@ parseArgs xs =
 
 loadCommand :: (MonadState ReplState m, MonadIO m) => String -> m ()
 loadCommand arg = case parseArgs arg of
-                    [file] -> loadFile file
+                    [file] -> loadFile (Just file)
                     _ -> outputDoc "Usage `:load [file]`"
 
 reloadCommand :: (MonadState ReplState m, MonadIO m) => m ()
-reloadCommand = do
-  file <- gets currentFile
-  case file of
-    Nothing -> outputDoc "No module to reload"
-    Just file -> loadFile file
+reloadCommand = loadFile =<< gets currentFile
 
 infoCommand :: (MonadState ReplState m, MonadIO m) => String -> m ()
 infoCommand (T.pack . dropWhile isSpace -> input) = do
@@ -286,7 +293,7 @@ compileCommand (dropWhile isSpace -> path) = do
   case current of
     Just file -> do
       in_p <- liftIO $ canonicalizePath file
-      (core, errors) <- wrapDriver $ D.tick >> D.compile in_p
+      (core, errors) <- wrapDriver $ D.tick >> D.compiles in_p
       handle <- liftIO $ openFile path WriteMode
 
       case core of
@@ -436,34 +443,25 @@ emitCore core = do
   pure (luaExpr, luaSyntax)
 
 -- | Reset the environment and load a series of files from environment
-loadFile :: (MonadState ReplState m, MonadIO m) => FilePath -> m ()
+loadFile :: (MonadState ReplState m, MonadIO m) => Maybe FilePath -> m ()
 loadFile file = do
   -- Reset the state
-  config <- gets config
-  handle <- gets outputHandle
-  driver <- gets driver
-  state' <- liftIO (defaultState config)
-  put state' { currentFile = Just file
-             , outputHandle = handle
-             , driver = driver }
-
+  put =<< (liftIO . resetState) =<< get
+  modify (\s ->  s { currentFile = file })
   wrapDriver D.tock
 
-  -- FIXME: This is a little broken, in that if the prelude and the
-  -- loaded file both require the same code, we will execute it
-  -- twice. Ideally we should probably have a 'loadFilsImpl', which loads
-  -- 1..n files, and correctly handles stitching them together.
-  _ <- setupPrelude
+  -- Determine whether to load the prelude and an additional file.
+  prelude <- gets (toList . prelude . config)
+  load <- case file of
+    Nothing -> pure []
+    Just file -> do
+      path <- liftIO $ canonicalizePath file
+      exists <- liftIO $ doesFileExist path
+      if exists
+      then outputDoc ("Loading:" <+> verbatim file) $> [path]
+      else outputDoc ("Cannot open" <+> verbatim file) $> []
 
-  -- Load each file in turn
-  path <- liftIO $ canonicalizePath file
-  exists <- liftIO $ doesFileExist path
-  if not exists
-  then outputDoc ("Cannot open" <+> verbatim file)
-  else do
-    outputDoc $ "Loading:" <+> verbatim file
-    loadFileImpl path $> ()
-
+  loadFiles (prelude ++ load) $> ()
 
 outputDoc :: (MonadState ReplState m, MonadIO m) => Doc -> m ()
 outputDoc x = do
@@ -486,9 +484,10 @@ runRemoteReplCommand port command = Net.withSocketsDo $ do
     Left (_ :: SomeException) ->
       putStrLn $ "Failed to connect to server on port " ++ show port
 
-loadFileImpl :: (MonadState ReplState m, MonadIO m) => FilePath -> m Bool
-loadFileImpl path = do
-  (core, es) <- wrapDriver $ D.tick >> D.compile path
+loadFiles :: (MonadState ReplState m, MonadIO m) => [FilePath] -> m Bool
+loadFiles [] = pure True
+loadFiles paths = do
+  (core, es) <- wrapDriver $ D.tick >> D.compile paths
 
   files <- D.fileMap =<< gets driver
   handle <- gets outputHandle
@@ -496,25 +495,27 @@ loadFileImpl path = do
   case core of
     Nothing -> pure False
     Just core -> do
-      (sig, env, lEnv) <- wrapDriver $ do
-        ~(Just sig) <- D.getSignature path
-        ~(Just env) <- D.getOpenedTypeEnv path
-        ~(Just lEnv) <- D.getLowerState path
-        pure (sig, env, lEnv)
+      oldEnv <- gets inferScope
+      for_ paths $ \path -> do
+        (sig, env, lEnv) <- wrapDriver $ do
+          ~(Just sig) <- D.getSignature path
+          ~(Just env) <- D.getOpenedTypeEnv path
+          ~(Just lEnv) <- D.getLowerState path
+          pure (sig, env, lEnv)
 
-      modify (\s -> s { resolveScope = resolveScope s <> sig
-                      , inferScope = inferScope s <> env
-                      , lowerState = lowerState s <> lEnv })
+        modify (\s -> s { resolveScope = resolveScope s <> sig
+                        , inferScope = inferScope s <> env
+                        , lowerState = lowerState s <> lEnv })
+      newEnv <- gets inferScope
 
       (luaExpr, luaSyntax) <- emitCore core
 
       luaState <- gets luaState
       debug <- gets (debugMode . config)
       liftIO $ do
-        dump debug [] core core luaExpr Bi.builtinEnv env
+        dump debug [] core core luaExpr oldEnv newEnv
         res <- L.runWith luaState $ do
           code <- L.dostring luaSyntax
-
           case code of
             L.OK -> pure (Right ())
             _ -> do
@@ -528,19 +529,12 @@ loadFileImpl path = do
           Left err -> hPutDoc handle err >> pure False
           Right () -> pure True
 
-setupPrelude :: (MonadState ReplState m, MonadIO m) => m Bool
-setupPrelude = do
-  prelude <- gets (prelude . config)
-  case prelude of
-    Nothing -> pure True
-    Just prelude -> loadFileImpl prelude
-
 repl :: ReplConfig -> IO ()
 repl config = replFrom config Nothing
 
 replFrom :: ReplConfig -> Maybe FilePath -> IO ()
 replFrom config file = do
-  state <- execStateT (maybe (setupPrelude $> ()) loadFile file) =<< defaultState config
+  state <- execStateT (loadFile file) =<< defaultState config
   hSetBuffering stdout LineBuffering
 
   ready <- newEmptyMVar

--- a/bin/Amc/Repl.hs
+++ b/bin/Amc/Repl.hs
@@ -438,9 +438,13 @@ loadFile file = do
   -- Reset the state
   config <- gets config
   handle <- gets outputHandle
+  driver <- gets driver
   state' <- liftIO (defaultState config)
   put state' { currentFile = Just file
-             , outputHandle = handle }
+             , outputHandle = handle
+             , driver = driver }
+
+  wrapDriver D.tock
 
   -- FIXME: This is a little broken, in that if the prelude and the
   -- loaded file both require the same code, we will execute it

--- a/bin/GenExample.hs
+++ b/bin/GenExample.hs
@@ -31,7 +31,7 @@ main = do
   (((core, errors), driver), _) <-
       flip runNameyT firstName
     . flip runStateT driver
-    $ compile file
+    $ compiles file
 
   x <- T.readFile file
 

--- a/src/Frontend/Driver.hs
+++ b/src/Frontend/Driver.hs
@@ -26,6 +26,9 @@ module Frontend.Driver
   , fileMap
   , getConfig, adjustConfig
 
+  -- * Cache invalidation
+  , tick, tock
+
   -- * REPL interaction
   --
   -- $repl
@@ -56,9 +59,11 @@ import Control.Monad.Namey
 import Control.Applicative
 import Control.Lens hiding ((<.>))
 
+import qualified Data.Text.Lazy.Encoding as L
+import qualified Data.ByteString.Lazy as BSL
 import qualified Data.List.NonEmpty as E
 import qualified Data.Map.Strict as Map
-import qualified Data.Text.Lazy.IO as L
+import qualified Data.ByteString as BS
 import qualified Data.Sequence as Seq
 import qualified Data.Text.IO as T
 import qualified Data.Text as T
@@ -70,6 +75,8 @@ import Data.Monoid
 import Data.Maybe
 import Data.These
 import Data.Span
+
+import qualified Crypto.Hash.SHA256 as SHA
 
 import Core.Core (Stmt)
 import Core.Var (CoVar)
@@ -94,6 +101,8 @@ import Frontend.Errors
 
 import Text.Pretty.Note
 
+import Debug.Trace
+
 -- | The stage a file is at. Files are parsed, resolved, type checked,
 -- verified, and then lowered.
 --
@@ -108,6 +117,7 @@ data Stage
   = SParsed     { _pBody :: [Toplevel Parsed] }
   | SUnparsed
 
+  | SResolving
   | SResolved   { _rBody :: [Toplevel Resolved], sig :: Signature }
   | SUnresolved
 
@@ -120,10 +130,24 @@ data Stage
   | SEmitted    { _cBody :: [Stmt CoVar],        sig :: Signature, env :: Env, _lowerState :: LowerState }
   deriving Show
 
+-- | A clock, composed of a major 'cTock' counter and a minor 'cTick' counter.
+--
+-- Ticks represent a "minor" change to the cache, which does not require
+-- us to update the executable state. Any file which has not yet been
+-- emitted may be reloaded at this point.
+--
+-- Tocks are used for a major change, where we will dispose of the whole
+-- executable state. Any module may be reloaded at this point.
+data Clock = Clock { cTock :: Int, cTick :: Int }
+  deriving (Show, Eq, Ord)
+
 data LoadedFile = LoadedFile
   { fileLocation :: FilePath
-  , fileSource :: SourceName
-  , fileVar :: Name
+  , fileSource   :: SourceName
+  , fileVar      :: Name
+
+  , fileHash    :: BS.ByteString
+  , fileClock   :: Clock
 
   -- | Files upon which this one depends.
   , _dependencies :: Set.Set FilePath
@@ -145,8 +169,8 @@ newtype DriverConfig = DriverConfig
 data Driver = Driver
   { -- | All loaded files.
     _files :: Map.Map FilePath LoadedFile
-  -- | A mapping of pretty source paths, to cannonical file names.
-  , _filePaths :: Map.Map SourceName FilePath
+    -- | The current clock of the loader.
+  , _clock :: Clock
   -- | The driver's current config
   , _config :: DriverConfig
   } deriving Show
@@ -156,11 +180,11 @@ makeLenses ''Driver
 
 -- | Construct a new driver from the given config.
 makeDriverWith :: DriverConfig -> Driver
-makeDriverWith = Driver mempty mempty
+makeDriverWith = Driver mempty (Clock 0 0)
 
 -- | Construct a new driver using 'makeConfig'.
 makeDriver :: IO Driver
-makeDriver = Driver mempty mempty <$> makeConfig
+makeDriver = Driver mempty (Clock 0 0) <$> makeConfig
 
 -- | The default driver config.
 --
@@ -204,6 +228,19 @@ getConfig = _config
 
 adjustConfig :: MonadState Driver m => (DriverConfig -> DriverConfig) -> m ()
 adjustConfig = (config%=)
+
+-- | Update the drivers's internal counter, allowing to reload any
+-- non-emitted files.
+tick :: MonadState Driver m => m ()
+tick = clock %= \(Clock to ti) -> Clock to (ti + 1)
+
+-- | Update the driver's internal counter, allowing it to reload any
+-- emitted file.
+--
+-- This should only be used in conjunction with resetting your execution
+-- state (such as a Lua environment).
+tock :: MonadState Driver m => m ()
+tock = clock %= \(Clock to _) -> Clock (to + 1) 0
 
 {- $repl
 
@@ -360,45 +397,86 @@ verifyProg v env inferred =
    occurred in the process of loading this file.
 -}
 
-addFile :: (MonadNamey m, MonadState Driver m, MonadIO m)
+-- | Get a file, reloading from disk if the cache state has changed.
+getFile :: forall m. (MonadNamey m, MonadState Driver m, MonadIO m)
         => FilePath -> m LoadedFile
-addFile path = do
-  name <- liftIO $ makeRelativeToCurrentDirectory path
-  var <- genNameFrom (T.pack ("\"" ++ name ++ "\""))
-  contents <- liftIO $ L.readFile path
-  let (parsed, es) = runParser name contents parseTops
-  let file = LoadedFile
-        { fileLocation = path
-        , fileSource = name
-        , fileVar = var
+getFile = fmap (fst . fromJust) . reloadFile where
+  -- | Get or reload a file, returning it and whether it changed.
+  reloadFile :: FilePath -> m (Maybe (LoadedFile, Bool))
+  reloadFile path = do
+    file <- use (files . at path)
+    clock <- use clock
+    case file of
+      Nothing -> do
+        contents <- read path
+        case contents of
+          Nothing -> pure Nothing
+          Just (sha, contents) -> do
+            -- File isn't in cache: add it.
+            name <- liftIO $ makeRelativeToCurrentDirectory path
+            var <- genNameFrom (T.pack ("\"" ++ name ++ "\""))
+            Just . (,True) <$> addFile path name var sha contents
 
-        , _dependencies = mempty
-        , _dependent = Nothing
+      Just file
+        | fileClock file == clock -> pure (Just (file, False))
+        | otherwise -> do
+          contents <- read path
+          case contents of
+            Nothing ->
+              -- Remove file from cache if it doesn't exist on disk
+              (files %= Map.delete path) $> Nothing
+            Just (sha, contents)
+              | sha /= fileHash file ->
+                -- If it's been updated on disk, just reload it immediately.
+                Just . (,True) <$> addFile path (fileSource file) (fileVar file) sha contents
+              | otherwise -> do
+                -- Otherwise check each dependency.
+                Any changed <- foldMapM (fmap (Any . maybe True snd) . reloadFile) (file ^. dependencies)
+                if changed
+                then Just . (,True) <$> addFile path (fileSource file) (fileVar file) sha contents
+                else pure (Just (file, False))
 
-        , _stage = maybe SUnparsed SParsed parsed
+  read :: FilePath -> m (Maybe (BS.ByteString, BSL.ByteString))
+  read path = do
+    exists <- liftIO $ doesFileExist path
+    if not exists then pure Nothing else do
+      contents <- liftIO $ BSL.readFile path
+      pure (Just (SHA.hashlazy contents, contents))
 
-        , _errors = mempty & parseErrors .~ es
-        }
+  addFile :: FilePath -> String -> Name -> BS.ByteString -> BSL.ByteString -> m LoadedFile
+  addFile path name var hash contents = do
+    clock <- use clock
+    let (parsed, es) = runParser name (L.decodeUtf8 contents) parseTops
+    let file = LoadedFile
+          { fileLocation = path
+          , fileSource   = name
+          , fileVar      = var
 
-  filePaths %= Map.insert name path
-  files %= Map.insert path file
+          , fileHash    = hash
+          , fileClock   = clock
 
-  pure file
+          , _dependencies = mempty
+          , _dependent = Nothing
+
+          , _stage = maybe SUnparsed SParsed parsed
+
+          , _errors = mempty & parseErrors .~ es
+          }
+
+    files %= Map.insert path file
+
+    pure file
 
 -- | Get or compute a file's signature.
 getSignature :: (MonadNamey m, MonadState Driver m, MonadIO m)
              => FilePath -> m (Maybe Signature)
 getSignature path = do
-  file <- use (files . at path)
-  file <- case file of
-    Nothing -> do
-      exists <- liftIO $ doesFileExist path
-      if exists then Just <$> addFile path else pure Nothing
-    Just file -> pure (Just file)
-
-  case maybe SUnparsed (^. stage) file of
+  file <- getFile path
+  case file ^. stage of
     SUnparsed -> pure Nothing
     SParsed parsed -> do
+      updateFile path $ stage .~ SResolving
+      traceM ("Resolving " ++ path)
       (resolved, deps) <-
           flip runFileImport (LoadContext (dropFileName path) (Just path))
         $ resolveProgram builtinResolve parsed
@@ -426,6 +504,7 @@ getTypeEnv path = do
     SUnresolved{} -> pure Nothing
     SUntyped{} -> pure Nothing
 
+    SResolving{} -> error "Impossible SResolving - should have been resolved."
     SResolved { _rBody = rBody, sig } -> do
       let ~(Just file') = file
       AllOf env <- foldMapM (fmap AllOf . getTypeEnv) (file' ^. dependencies)
@@ -483,6 +562,7 @@ getVerified path = do
     SUntyped{} -> pure False
     SUnresolved{} -> pure False
 
+    SResolving{} -> error "Impossible SResolving - should have been resolved."
     SResolved{} -> error "Impossible SResolved - should have been typed."
 
     -- Already done
@@ -613,22 +693,21 @@ importFile :: (MonadNamey m, MonadState Driver m, MonadIO m)
 importFile fromPath fromLoc path = do
   file <- use (files . at path)
   case file of
-    Just file -> do
+    Just{} -> do
+      file <- getFile path
       case file ^. stage of
-        SUnresolved -> pure Errored
-        SUnparsed -> pure Errored
-        SParsed _ -> do
+        SResolving -> do
           state <- get
           let ~(Just loc) = fromLoc
               fromFile = flip Map.lookup (state ^. files) =<< fromPath
           pure (ImportCycle ((fileSource file, loc) E.:| foldMap (`findCycle` state) fromFile))
 
-        stage -> pure (Imported (fileVar file) (sig stage))
+        _ -> maybe Errored (Imported (fileVar file)) <$> getSignature path
 
     Nothing -> do
       exists <- liftIO $ doesFileExist path
       if not exists then pure NotFound else do
-        file <- addFile path
+        file <- getFile path
         updateFile path $ dependent .~ ((,) <$> fromPath <*> fromLoc)
         maybe Errored (Imported (fileVar file)) <$> getSignature path
 


### PR DESCRIPTION
This implements the design as discussed in #183:

 - The driver now has a "clock", with a major and minor counter.
   - Counters are used to mark places where we expect loaded files to change. Otherwise you may have a file change between a call to `getSignature` and `getLowered`, which is terribly confusing.
   - Ticks (minor updates), allow non-emitted files to be reloaded if they have changed. This means you can reimport erroring files within the repl, and we will attempt recompilation.
   - Tocks (major updates), reloads any changed file. This is only done when using `:[re]load`, as you need to throw away any existing values at the same time.
 - The REPL now keeps the same driver around for the whole session, ticking and tocking it where appropriate.
 - Files are considered to have changed if their SHA256 hash has changed, or any of their dependencies have changed.

It's worth noting that the REPL is still a little slow to run after each `:r`, as we still need to _emit and run_ the appropriate Lua code, which takes a bit of time. It might be possible to defer the running of non-critical Lua code, but doing so is a much harder challenge.

**Edit:** Actually, it's not as bad as I thought it was - just tried it outside of ghci, and the performance is fine, so it probably isn't down to Lua.