### PR TITLE
Add a basic watch mode for compilation

### DIFF
--- a/amuletml.cabal
+++ b/amuletml.cabal
@@ -27,6 +27,8 @@ executable amc
                      , network >= 3.1 && < 3.2
                      , process >= 1.6 && < 1.7
                      , amuletml
+                     , filepath >= 1.4 && < 1.5
+                     , fsnotify >= 0.3 && < 0.4
                      , directory >= 1.3 && < 1.4
                      , haskeline >= 0.7 && < 0.8
                      , containers >= 0.5 && < 0.7
@@ -36,8 +38,9 @@ executable amc
                      , template-haskell >= 2.13 && < 2.16
                      , pretty-show
 
-  other-modules:       Amc.Debug
-                     , Version
+  other-modules:       Version
+                     , Amc.Debug
+                     , Amc.Compile
                      , Amc.Repl
                      , Amc.Repl.Display
   default-language:    Haskell2010

--- a/bin/Amc/Compile.hs
+++ b/bin/Amc/Compile.hs
@@ -1,0 +1,126 @@
+{-# LANGUAGE NamedFieldPuns, RankNTypes #-}
+module Amc.Compile
+  ( Optimise(..)
+  , Options(..)
+  , compileFile
+  , watchFile
+  ) where
+
+import System.Directory
+import System.FilePath
+import System.FSNotify
+
+import Control.Monad.Infer (firstName)
+import Control.Monad.Namey
+import Control.Monad.State
+import Control.Concurrent
+
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+import Data.Position (SourceName)
+import Data.Foldable
+import Data.Functor
+import Data.List
+
+import Backend.Lua
+
+import Syntax.Resolve.Scope (exportedNames)
+import Core.Optimise.DeadCode (deadCodePass)
+import Core.Optimise.Reduce (reducePass)
+import Core.Simplify
+import Core.Lint
+
+import Text.Pretty.Semantic hiding (empty)
+
+import qualified Frontend.Driver as D
+import Frontend.Errors
+
+import qualified Amc.Debug as D
+
+data Optimise = Opt | NoOpt
+  deriving Show
+
+data Options = Options
+  { optLevel :: Optimise
+  , lint     :: Bool
+  , export   :: Bool
+  , debug    :: D.DebugMode
+  }
+  deriving Show
+
+compileIt :: Options -> D.Driver -> SourceName
+          -> (Doc -> IO ())
+          -> IO (D.Driver, Set.Set FilePath)
+compileIt Options { optLevel, lint, export, debug } driver file emit = do
+  path <- canonicalizePath file
+  ((((core, errors), sig), driver), name) <-
+      flip runNameyT firstName
+    . flip runStateT driver
+    $ (,) <$> D.compiles path <*> D.getSignature path
+
+  files <- D.fileMap driver
+  reportAllS files errors
+
+  case core of
+    Nothing -> pure ()
+    Just core -> do
+      let sig' = if export then sig else Nothing
+          info = defaultInfo { useLint = lint
+                             , exportNames = foldMap exportedNames sig' }
+          optimised = flip evalNamey name $ case optLevel of
+            Opt -> optimise info core
+            NoOpt -> do
+              lintIt "Lower" (checkStmt emptyScope core) (pure ())
+              (lintIt "Optimised"  =<< checkStmt emptyScope) . deadCodePass info <$> reducePass info core
+          lua = compileProgram sig' optimised
+      D.dumpCore debug core optimised lua
+      emit (pretty lua)
+
+  fileNames <- traverse (canonicalizePath . fst) files
+  pure (driver, Set.fromList fileNames)
+  where
+    lintIt name = if lint then runLint name else flip const
+
+-- | Compile a file, passing the result to some "emitting function", such
+-- as writing to a file or the terminal.
+compileFile :: Options -> D.DriverConfig -> SourceName
+            -> (Doc -> IO ())
+            -> IO ()
+compileFile opt config file emit = compileIt opt (D.makeDriverWith config) file emit $> ()
+
+-- | Compile a file, and then watch for c
+watchFile :: Options -> D.DriverConfig -> SourceName
+          -> (Doc -> IO ())
+          -> IO ()
+watchFile opt config file emit = do
+  chan <- newChan
+  withManager (go mempty (D.makeDriverWith config) chan)
+
+  where
+    go :: Map.Map FilePath StopListening -> D.Driver -> EventChannel -> WatchManager -> IO ()
+    go dirs driver channel mgr = do
+      (driver, files) <- compileIt opt driver file emit
+
+      -- Update the files we're currently watching.
+      let newDirs = Set.map dropFileName files
+      sequence_ (Map.withoutKeys dirs newDirs)
+      dirs' <- foldrM
+        (\dir dirs -> do
+            putStrLn ("Watching " ++ quot dir)
+            cancel <- watchDirChan mgr dir (const True) channel
+            pure (Map.insert dir cancel dirs))
+        dirs (newDirs Set.\\ Map.keysSet dirs)
+
+      changes <- wait files channel
+      putStrLn ("File(s) " ++ intercalate ", " (map quot changes) ++ " changed.")
+      go dirs' (execState D.tock driver) channel mgr
+
+    quot x = "'" ++ x ++ "'"
+
+    wait :: Set.Set FilePath -> EventChannel -> IO [FilePath]
+    wait files chan = do
+      changed <- eventPath <$> readChan chan
+      path <- liftIO $ canonicalizePath changed
+      if Set.member path files
+      then pure [path]
+      else wait files chan

--- a/tests/amc/usage.t
+++ b/tests/amc/usage.t
@@ -16,7 +16,8 @@ Using amc with the help flag displays all sub-command and the top-level options.
 Each sub-command can be run with --help too.
 
   $ amc compile --help
-  Usage: amc compile FILE [-o|--out FILE] [-O|--opt LEVEL] [--export] [--lib ARG]
+  Usage: amc compile FILE [-o|--out FILE] [-O|--opt LEVEL] [--export] [--watch] 
+                     [--lib ARG]
     Compile an Amulet file to Lua.
   
   Available options:
@@ -25,6 +26,8 @@ Each sub-command can be run with --help too.
     -O,--opt LEVEL           Controls the optimisation level. (default: 1)
     --export                 Export all declared variables in this module,
                              returning them at the end of the program.
+    --watch                  After compiling, watch for further changes to the
+                             file and recompile it again.
     -t,--test                Provides additional debug information on the output
     --test-tc                Provides additional type check information on the
                              output


### PR DESCRIPTION
One may now run `amc compile test.ml --watch -o out.lua`, and it will recompile whenever `test.ml`, or any of its dependencies change. File watchers on dependencies are automatically registered/unregistered.

Note, there's currently a few places where there is room for improvement:
 - This currently has no additional debouncing (beyond what is done within fsnotify). I did think about adding some, but found I didn't really need any quite yet.

 - Related to that, this will run compilation to completion. Ideally we would cancel compilation if files changed during it, and restart (while still keeping as much progress as possible).

 - Most time is currently spent in the optimiser. It'd be nice to have per-module optimisations, but there's a _lot_ of plumbing needed to get to that stage.