### PR TITLE
Qualify names when leaving a module

### DIFF
--- a/src/Syntax/Resolve.hs
+++ b/src/Syntax/Resolve.hs
@@ -599,7 +599,12 @@ lookupIn g nonRec v k = go v where
 lookupSlot :: MonadResolve m
            => Var Parsed -> Slot
            -> m (Var Resolved)
-lookupSlot _ (SVar x) = pure x
+lookupSlot v (SVar x) = pure $
+  let toName (Name x) = x
+      toName (InModule t x) = t <> T.singleton '.' <> toName x
+   in case x of
+     TgInternal n -> TgInternal n
+     TgName _ id -> TgName (toName v) id
 lookupSlot v (SAmbiguous vs) = confesses (Ambiguous v vs)
 
 -- | Lookup a value/expression variable.

--- a/src/Syntax/Types.hs
+++ b/src/Syntax/Types.hs
@@ -3,7 +3,7 @@
   , TypeFamilies, TemplateHaskell, FunctionalDependencies, RankNTypes #-}
 module Syntax.Types
   ( Telescope, one, foldTele, foldTeleM, teleFromList, mapTele, traverseTele, teleToList
-  , Scope(..), namesInScope, inScope, scopeToList
+  , Scope(..), namesInScope, inScope, scopeToList, mapScope
   , Env, freeInEnv, difference, envOf, scopeFromList, toMap
   , names, typeVars, constructors, types, letBound, classes, modules
   , classDecs, tySyms, declaredHere
@@ -202,6 +202,9 @@ scopeToList (Scope m) = Map.toList m
 
 inScope :: Ord (Var p) => Var p -> Scope p f -> Bool
 inScope v (Scope m) = v `Map.member` m
+
+mapScope :: (Var p -> Var p) -> (f -> f) -> Scope p f -> Scope p f
+mapScope k k' (Scope m) = Scope (k' <$> Map.mapKeysMonotonic k m)
 
 focus :: Telescope t -> Scope Resolved (Type t) -> Scope Resolved (Type t)
 focus m s = Scope (getScope s <> getTele m)

--- a/tests/resolve/pass_include.out
+++ b/tests/resolve/pass_include.out
@@ -6,4 +6,4 @@ module Y#2 = begin
   include X#0
 end
 foreign val +#4 : int -> int -> int = "function(x, y) return x + y end"
-let _ = (x#1 +#4 y#3)
+let _ = (Y.x#1 +#4 Y.y#3)

--- a/tests/resolve/pass_modules.out
+++ b/tests/resolve/pass_modules.out
@@ -4,7 +4,7 @@ module X#0 = begin
   end
 end
 module Z#3 = Y#1
-let a#4 = x#2
+let a#4 = Z.x#2
 open X#0
-let b#5 = x#2
-let z#6 = X#0.({ a = x#2 })
+let b#5 = Y.x#2
+let z#6 = X#0.({ a = Y.x#2 })

--- a/tests/types/class/assoc-eta.out
+++ b/tests/types/class/assoc-eta.out
@@ -1,5 +1,5 @@
 has_sing : Req{'k : type}. constraint
 sing_t : Req{'k : type}. 'k -> type
 sint : int -> type
-SInt : Spec{'i : int}. known_int 'i => sint 'i
+SInt : Spec{'i : int}. Amc.known_int 'i => sint 'i
 sing : sing_t int 123

--- a/tests/types/letopen.out
+++ b/tests/types/letopen.out
@@ -1,2 +1,2 @@
-foo : Req{'a : type}. constraint
-foo_it : Spec{'a : type}. foo 'a => 'a -> unit
+Foo.foo : Req{'a : type}. constraint
+Foo.foo_it : Spec{'a : type}. Foo.foo 'a => 'a -> Foo.unit

--- a/tests/types/scope.ml
+++ b/tests/types/scope.ml
@@ -1,0 +1,19 @@
+external val (+) : int -> int -> int =
+  "function(x, y) return x + y end"
+
+module X = begin
+  type t = T
+  let x = T
+end
+
+let _ =
+  let _ = X.x + 1
+  (* local opens unqualify *)
+  let _ =
+    let open X
+    x + 1
+  let _ = X.( x + 1 )
+
+  (* make sure that the unqualified scope doesn't leak *)
+  let _ = X.x + 1
+  ()

--- a/tests/types/scope.out
+++ b/tests/types/scope.out
@@ -1,0 +1,24 @@
+scope.ml[10:11 ..10:13]: error (E2001)
+   │ 
+10 │   let _ = X.x + 1
+   │           ^^^
+  Couldn't match actual type X.t
+    with the type expected by the context, int
+scope.ml[14:5 ..14:5]: error (E2001)
+   │ 
+14 │     x + 1
+   │     ^
+  Couldn't match actual type t
+    with the type expected by the context, int
+scope.ml[15:15 ..15:15]: error (E2001)
+   │ 
+15 │   let _ = X.( x + 1 )
+   │               ^
+  Couldn't match actual type t
+    with the type expected by the context, int
+scope.ml[18:11 ..18:13]: error (E2001)
+   │ 
+18 │   let _ = X.x + 1
+   │           ^^^
+  Couldn't match actual type X.t
+    with the type expected by the context, int


### PR DESCRIPTION
And, indeed, unqualify names when leaving a module. In practice, this
means that the entire TC scope consists of types that are writable, as
printed, in the scope they are referring to. This fixes:

1. Printing of types in error messages
2. Suggestions offered by ~~amuse~~ `Types.Holes`